### PR TITLE
Fix 6502 stack/return timing and accept Apple II ROM binaries in Apple2Bus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 *.rbc
 .DS_Store
 .rspec_status
+/spec/fixtures/apple2/

--- a/docs/apple2_io.md
+++ b/docs/apple2_io.md
@@ -1,0 +1,56 @@
+# Apple ][-style I/O support
+
+This project includes a minimal Apple ][ / Apple ][+ style I/O bus for the 6502 core
+to run unmodified Apple II binaries in tests. The implementation is intentionally
+lightweight and focuses on memory-mapped I/O behavior rather than video rendering.
+
+## Supported address ranges
+
+### RAM
+
+* `0x0000-0xBFFF`: read/write RAM (including text page memory at `0x0400-0x07FF`).
+
+### I/O page (`0xC000-0xC0FF`)
+
+#### Keyboard
+
+* `0xC000`: read keyboard data. Returns the last key value with bit 7 set if a key is
+  pending, or `0x00` if no key is ready.
+* `0xC010`: clear the keyboard strobe (read or write).
+
+#### Speaker
+
+* `0xC030`: toggles the speaker click on any access (read or write). The bus records
+  speaker toggles for tests.
+
+#### Video soft switches (state only)
+
+The following soft switches update internal video mode state when accessed (read or write):
+
+* `0xC050`: graphics mode (text off)
+* `0xC051`: text mode (text on)
+* `0xC052`: mixed off
+* `0xC053`: mixed on
+* `0xC054`: page2 off (page1)
+* `0xC055`: page2 on
+* `0xC056`: hires off (lores)
+* `0xC057`: hires on
+
+### ROM
+
+* ROM images can be loaded into any address range (e.g., `0xF800-0xFFFF` for the
+  Apple ][ Dead Test ROM). Writes to ROM addresses are ignored.
+
+## Known limitations
+
+* No disk controller emulation.
+* No video rendering; only memory and soft-switch state are tracked.
+* No Apple II ROM calls yet (e.g., `COUT` at `0xFDED` is future work).
+
+## Running the Apple II binary tests
+
+The Apple ][ Dead Test ROM is downloaded on demand to `spec/fixtures/apple2/apple2dead.bin`.
+
+```bash
+bundle exec rspec spec/apple2_deadtest_spec.rb
+```

--- a/examples/mos6502/apple2_bus.rb
+++ b/examples/mos6502/apple2_bus.rb
@@ -1,0 +1,172 @@
+# Apple ][-style memory bus with I/O page and soft switches
+
+require_relative '../../lib/rhdl/hdl'
+
+module MOS6502
+  class Apple2Bus < RHDL::HDL::SimComponent
+    IO_PAGE_START = 0xC000
+    IO_PAGE_END = 0xC0FF
+
+    TEXT_PAGE1_START = 0x0400
+    TEXT_PAGE1_END = 0x07FF
+
+    ROM_START = 0xF800
+    ROM_END = 0xFFFF
+
+    SOFT_SWITCHES = {
+      0xC050 => [:text, false], # GRAPHICS
+      0xC051 => [:text, true],  # TEXT
+      0xC052 => [:mixed, false],
+      0xC053 => [:mixed, true],
+      0xC054 => [:page2, false],
+      0xC055 => [:page2, true],
+      0xC056 => [:hires, false],
+      0xC057 => [:hires, true]
+    }.freeze
+
+    attr_reader :speaker_toggles, :video
+
+    def initialize(name = nil)
+      @memory = Array.new(0x10000, 0)
+      @rom_mask = Array.new(0x10000, false)
+      @prev_clk = 0
+      @key_ready = false
+      @key_value = 0
+      @speaker_toggles = 0
+      @video = {
+        text: true,
+        mixed: false,
+        page2: false,
+        hires: false
+      }
+      @soft_switch_access = Hash.new(0)
+      super(name)
+    end
+
+    def setup_ports
+      input :clk
+      input :addr, width: 16
+      input :data_in, width: 8
+      input :rw
+      input :cs
+
+      output :data_out, width: 8
+    end
+
+    def rising_edge?
+      prev = @prev_clk
+      @prev_clk = in_val(:clk)
+      prev == 0 && @prev_clk == 1
+    end
+
+    def propagate
+      addr = in_val(:addr) & 0xFFFF
+      cs = in_val(:cs)
+      rw = in_val(:rw)
+
+      if cs == 1
+        if rising_edge? && rw == 0
+          handle_write(addr, in_val(:data_in))
+        end
+
+        out_set(:data_out, handle_read(addr))
+      else
+        out_set(:data_out, 0)
+      end
+    end
+
+    def read(addr)
+      handle_read(addr & 0xFFFF)
+    end
+
+    def write(addr, data)
+      handle_write(addr & 0xFFFF, data)
+    end
+
+    def load_rom(bytes, base_addr:)
+      to_bytes(bytes).each_with_index do |byte, i|
+        addr = (base_addr + i) & 0xFFFF
+        @memory[addr] = byte & 0xFF
+        @rom_mask[addr] = true
+      end
+    end
+
+    def load_ram(bytes, base_addr:)
+      to_bytes(bytes).each_with_index do |byte, i|
+        addr = (base_addr + i) & 0xFFFF
+        @memory[addr] = byte & 0xFF
+        @rom_mask[addr] = false
+      end
+    end
+
+    def reset_vector
+      low = @memory[0xFFFC]
+      high = @memory[0xFFFD]
+      (high << 8) | low
+    end
+
+    def inject_key(ascii)
+      @key_value = ascii & 0x7F
+      @key_ready = true
+    end
+
+    def soft_switch_accessed?(addr)
+      @soft_switch_access[addr & 0xFFFF] > 0
+    end
+
+    def text_page_written?
+      (TEXT_PAGE1_START..TEXT_PAGE1_END).any? { |addr| @memory[addr] != 0 }
+    end
+
+    private
+
+    def handle_read(addr)
+      if io_page?(addr)
+        return handle_io(:read, addr, 0)
+      end
+
+      @memory[addr]
+    end
+
+    def handle_write(addr, value)
+      if io_page?(addr)
+        handle_io(:write, addr, value)
+        return
+      end
+
+      return if @rom_mask[addr]
+
+      @memory[addr] = value & 0xFF
+    end
+
+    def io_page?(addr)
+      addr >= IO_PAGE_START && addr <= IO_PAGE_END
+    end
+
+    def handle_io(direction, addr, value)
+      case addr
+      when 0xC000
+        @key_ready ? (@key_value | 0x80) : 0x00
+      when 0xC010
+        @key_ready = false
+        0x00
+      when 0xC030
+        @speaker_toggles += 1
+        0x00
+      else
+        if SOFT_SWITCHES.key?(addr)
+          setting, state = SOFT_SWITCHES[addr]
+          @video[setting] = state
+          @soft_switch_access[addr] += 1
+        end
+        0x00
+      end
+    end
+
+    def to_bytes(source)
+      return source.bytes if source.is_a?(String)
+
+      source
+    end
+  end
+end

--- a/examples/mos6502/control_unit.rb
+++ b/examples/mos6502/control_unit.rb
@@ -73,6 +73,7 @@ module MOS6502
 
       # Control outputs
       output :state, width: 8         # Current state
+      output :state_before, width: 8  # State before transition (for control alignment)
       output :pc_inc                  # Increment program counter
       output :pc_load                 # Load program counter
       output :load_opcode             # Load instruction register
@@ -99,6 +100,9 @@ module MOS6502
       # Output control signals FIRST, based on current state
       # This ensures the signals reflect the state BEFORE any transitions
       output_control_signals
+
+      # Output state BEFORE transition so it stays aligned with control outputs
+      out_set(:state_before, @state)
 
       # Then advance state machine on rising edge
       if rising_edge?

--- a/examples/mos6502/datapath.rb
+++ b/examples/mos6502/datapath.rb
@@ -106,17 +106,18 @@ module MOS6502
       @control.set_input(:writes_reg, @decoder.get_output(:writes_reg))
       @control.set_input(:is_status_op, @decoder.get_output(:is_status_op))
 
+      if clk == 0
+        @status_reg.propagate  # Get current status first
+        @registers.propagate
+        @pc.propagate
+        @sp.propagate
+      end
+
       # Status flags to control unit (for branch decisions)
-      @status_reg.propagate  # Get current status first
       @control.set_input(:flag_n, @status_reg.get_output(:n))
       @control.set_input(:flag_v, @status_reg.get_output(:v))
       @control.set_input(:flag_z, @status_reg.get_output(:z))
       @control.set_input(:flag_c, @status_reg.get_output(:c))
-
-      # Propagate registers to get current values
-      @registers.propagate
-      @pc.propagate
-      @sp.propagate
 
       reg_a = @registers.get_output(:a)
       reg_x = @registers.get_output(:x)
@@ -148,6 +149,7 @@ module MOS6502
       @addr_calc.set_input(:x_reg, reg_x)
       @addr_calc.propagate
 
+      state_before = @control.get_output(:state_before)
       state = @control.get_output(:state)
 
       # Address bus multiplexer based on addr_sel
@@ -202,22 +204,28 @@ module MOS6502
       # For RMW operations, latch the ALU result during EXECUTE
       # so we can use it during WRITE (after flags are updated)
       is_rmw = @decoder.get_output(:is_rmw)
-      if state == ControlUnit::STATE_EXECUTE && is_rmw == 1
+      if state_before == ControlUnit::STATE_EXECUTE && is_rmw == 1
         @rmw_result_latch = alu_result
       end
 
       # Update registers based on control signals
-      update_registers(dst_reg, alu_result, data_in, instr_type, addr_mode)
+      update_registers(dst_reg, alu_result, data_in, instr_type, addr_mode, state_before)
 
       # Update status register
-      update_status_flags(instr_type, addr_mode)
+      update_status_flags(instr_type, addr_mode, state_before)
 
       # Program counter updates
       @pc.set_input(:inc, @control.get_output(:pc_inc))
       @pc.set_input(:load, @control.get_output(:pc_load))
 
       # PC load address: from address latch for jumps, or computed for branches
-      pc_load_addr = select_pc_load_addr(state, eff_addr, @addr_latch.get_output(:addr))
+      pc_load_addr = select_pc_load_addr(
+        state_before,
+        eff_addr,
+        @addr_latch.get_output(:addr),
+        @addr_latch.get_output(:addr_lo),
+        data_in
+      )
       @pc.set_input(:addr_in, pc_load_addr)
       @pc.propagate
 
@@ -229,7 +237,7 @@ module MOS6502
 
       # Handle TXS instruction specially
       if instr_type == InstructionDecoder::TYPE_TRANSFER &&
-         state == ControlUnit::STATE_EXECUTE &&
+         state_before == ControlUnit::STATE_EXECUTE &&
          opcode == 0x9A  # TXS
         @sp.set_input(:load, 1)
         @sp.set_input(:data_in, reg_x)
@@ -240,12 +248,12 @@ module MOS6502
       # Data output multiplexer
       # For RMW operations in WRITE state, use the latched result from EXECUTE
       data_sel = @control.get_output(:data_sel)
-      effective_alu_result = if state == ControlUnit::STATE_WRITE_MEM && is_rmw == 1
+      effective_alu_result = if state_before == ControlUnit::STATE_WRITE_MEM && is_rmw == 1
         @rmw_result_latch
       else
         alu_result
       end
-      pc_for_data = if state == ControlUnit::STATE_JSR_PUSH_HI || state == ControlUnit::STATE_JSR_PUSH_LO
+      pc_for_data = if state_before == ControlUnit::STATE_JSR_PUSH_HI || state_before == ControlUnit::STATE_JSR_PUSH_LO
         (pc_val - 1) & 0xFFFF
       else
         pc_val
@@ -257,7 +265,7 @@ module MOS6502
       out_set(:addr, addr_out)
       out_set(:data_out, data_out)
       out_set(:rw, @control.get_output(:mem_write) == 1 ? 0 : 1)
-      out_set(:sync, state == ControlUnit::STATE_FETCH ? 1 : 0)
+      out_set(:sync, state_before == ControlUnit::STATE_FETCH ? 1 : 0)
 
       # Debug outputs
       out_set(:reg_a, reg_a)
@@ -318,28 +326,29 @@ module MOS6502
       end
     end
 
-    def select_pc_load_addr(state, eff_addr, latch_addr)
+    def select_pc_load_addr(state, eff_addr, latch_addr, latch_lo, data_in)
       case state
       when ControlUnit::STATE_BRANCH_TAKE
         eff_addr
-      when ControlUnit::STATE_RTS_PULL_HI,
-           ControlUnit::STATE_RTI_PULL_HI,
+      when ControlUnit::STATE_RTS_PULL_HI
+        addr = ((data_in & 0xFF) << 8) | latch_lo
+        (addr + 1) & 0xFFFF
+      when ControlUnit::STATE_RTI_PULL_HI,
            ControlUnit::STATE_BRK_VEC_HI
-        latch_addr
+        ((data_in & 0xFF) << 8) | latch_lo
       else
         eff_addr
       end
     end
 
-    def update_registers(dst_reg, alu_result, data_in, instr_type, addr_mode)
+    def update_registers(dst_reg, alu_result, data_in, instr_type, addr_mode, state_before)
       reg_write = @control.get_output(:reg_write)
-      state = @control.get_output(:state)
 
       @registers.set_input(:load_a, 0)
       @registers.set_input(:load_x, 0)
       @registers.set_input(:load_y, 0)
 
-      if reg_write == 1 && state == ControlUnit::STATE_EXECUTE
+      if reg_write == 1 && state_before == ControlUnit::STATE_EXECUTE
         # Determine what data to write
         write_data = if instr_type == InstructionDecoder::TYPE_LOAD
           if addr_mode == AddressGenerator::MODE_IMMEDIATE
@@ -395,8 +404,7 @@ module MOS6502
       end
     end
 
-    def update_status_flags(instr_type, addr_mode)
-      state = @control.get_output(:state)
+    def update_status_flags(instr_type, addr_mode, state_before)
       update = @control.get_output(:update_flags)
 
       @status_reg.set_input(:load_all, 0)
@@ -409,7 +417,7 @@ module MOS6502
       @status_reg.set_input(:load_d, 0)
       @status_reg.set_input(:load_b, 0)
 
-      if update == 1 && state == ControlUnit::STATE_EXECUTE
+      if update == 1 && state_before == ControlUnit::STATE_EXECUTE
         if instr_type == InstructionDecoder::TYPE_FLAG
           # Handle flag instructions
           handle_flag_instruction
@@ -434,7 +442,7 @@ module MOS6502
       end
 
       # Handle PLP instruction after pull completes
-      if state == ControlUnit::STATE_EXECUTE && instr_type == InstructionDecoder::TYPE_STACK
+      if state_before == ControlUnit::STATE_EXECUTE && instr_type == InstructionDecoder::TYPE_STACK
         opcode = @ir.get_output(:opcode)
         if opcode == 0x28  # PLP
           @status_reg.set_input(:data_in, @data_latch.get_output(:data))

--- a/examples/mos6502/registers.rb
+++ b/examples/mos6502/registers.rb
@@ -87,21 +87,24 @@ module MOS6502
     end
 
     def propagate
+      prev_state = @state
+      next_state = @state
       if rising_edge?
         if in_val(:rst) == 1
-          @state = 0xFD  # Reset value
+          next_state = 0xFD  # Reset value
         elsif in_val(:load) == 1
-          @state = in_val(:data_in) & 0xFF
+          next_state = in_val(:data_in) & 0xFF
         elsif in_val(:dec) == 1
-          @state = (@state - 1) & 0xFF
+          next_state = (prev_state - 1) & 0xFF
         elsif in_val(:inc) == 1
-          @state = (@state + 1) & 0xFF
+          next_state = (prev_state + 1) & 0xFF
         end
+        @state = next_state
       end
 
       out_set(:sp, @state)
-      out_set(:addr, STACK_BASE | @state)
-      out_set(:addr_plus1, STACK_BASE | ((@state + 1) & 0xFF))
+      out_set(:addr, STACK_BASE | prev_state)
+      out_set(:addr_plus1, STACK_BASE | ((prev_state + 1) & 0xFF))
     end
 
     # Direct access

--- a/lib/rhdl/hdl/diagram.rb
+++ b/lib/rhdl/hdl/diagram.rb
@@ -411,9 +411,7 @@ module RHDL
       def svg_header(width, height)
         <<~SVG
           <?xml version="1.0" encoding="UTF-8"?>
-          <svg xmlns="http://www.w3.org/2000/svg"
-               width="#{width}" height="#{height}"
-               viewBox="0 0 #{width} #{height}">
+          <svg xmlns="http://www.w3.org/2000/svg" width="#{width}" height="#{height}" viewBox="0 0 #{width} #{height}">
         SVG
       end
 

--- a/spec/apple2_deadtest_spec.rb
+++ b/spec/apple2_deadtest_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'open-uri'
+
+RSpec.describe 'Apple ][ dead test ROM' do
+  DEADTEST_URL = 'https://github.com/misterblack1/appleII_deadtest/releases/download/v1.0.1/apple2dead.bin'
+  FIXTURE_DIR = File.join(__dir__, 'fixtures', 'apple2')
+  FIXTURE_PATH = File.join(FIXTURE_DIR, 'apple2dead.bin')
+
+  def load_deadtest_rom
+    FileUtils.mkdir_p(FIXTURE_DIR)
+    unless File.exist?(FIXTURE_PATH)
+      URI.open(DEADTEST_URL) do |remote|
+        File.open(FIXTURE_PATH, 'wb') { |file| file.write(remote.read) }
+      end
+    end
+    File.binread(FIXTURE_PATH)
+  end
+
+  def boot_deadtest
+    runner = Apple2Harness::Runner.new
+    runner.load_rom(load_deadtest_rom, base_addr: 0xF800)
+    runner.reset
+    runner
+  end
+
+  it 'beeps the speaker after reset' do
+    runner = boot_deadtest
+    runner.run_until(max_cycles: 50_000) { runner.bus.speaker_toggles.positive? }
+    expect(runner.bus.speaker_toggles).to be > 0
+  end
+
+  it 'enters text mode via soft switches' do
+    runner = boot_deadtest
+    runner.run_until(max_cycles: 80_000) { runner.bus.soft_switch_accessed?(0xC051) }
+    expect(runner.bus.soft_switch_accessed?(0xC051)).to be(true)
+    expect(runner.bus.video[:text]).to be(true)
+  end
+
+  it 'writes to text page memory' do
+    runner = boot_deadtest
+    runner.run_steps(120_000)
+    expect(runner.bus.text_page_written?).to be(true)
+  end
+end

--- a/spec/support/apple2_harness.rb
+++ b/spec/support/apple2_harness.rb
@@ -1,0 +1,41 @@
+# Apple ][ test harness for MOS6502 CPU
+
+require_relative '../../examples/mos6502/cpu'
+require_relative '../../examples/mos6502/apple2_bus'
+
+module Apple2Harness
+  class Runner
+    attr_reader :cpu, :bus
+
+    def initialize
+      @bus = MOS6502::Apple2Bus.new("apple2_bus")
+      @cpu = MOS6502::CPU.new(@bus)
+    end
+
+    def load_rom(bytes, base_addr:)
+      @bus.load_rom(bytes, base_addr: base_addr)
+    end
+
+    def load_ram(bytes, base_addr:)
+      @bus.load_ram(bytes, base_addr: base_addr)
+    end
+
+    def reset
+      @cpu.reset
+    end
+
+    def run_steps(steps)
+      steps.times { @cpu.clock_cycle }
+    end
+
+    def run_until(max_cycles: 200_000)
+      cycles = 0
+      while cycles < max_cycles
+        @cpu.clock_cycle
+        cycles += 1
+        break if yield
+      end
+      cycles
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

- The Apple II Dead Test integration expected ROM bytes to be provided as raw binary strings and the bus loader needed to accept that form. 
- Several 6502 instruction tests failed due to incorrect timing when returning from stack (RTS/RTI/BRK) and stack address calculations. 
- SVG output formatting caused an SVG renderer spec failure and downloaded test fixtures should not be committed. 

### Description

- Update `Apple2Bus#load_rom` and `#load_ram` to accept either arrays of bytes or binary `String` by adding `to_bytes` and preserving ROM masks in `examples/mos6502/apple2_bus.rb`. 
- Correct stack pointer behavior by computing outputs from the previous SP for addr/address+1 and update the propagate logic in `examples/mos6502/registers.rb` so push/pop timing is consistent. 
- Align control and datapath timing by exporting a `state_before` in `ControlUnit` and having the `Datapath` use that pre-transition state for latching ALU/RMW results, register updates, PC load address computation (including RTS/RTI/BRK handling), and sync/data multiplexing in `examples/mos6502/control_unit.rb` and `examples/mos6502/datapath.rb`. 
- Fix SVG header formatting to a single line to satisfy the renderer spec in `lib/rhdl/hdl/diagram.rb` and add `/spec/fixtures/apple2/` to `.gitignore` to avoid committing downloaded binaries. 

### Testing

- Ran the full test suite with `bundle exec rspec` and it passed: 570 examples, 0 failures. 
- Exercised the Apple II Dead Test integration (`spec/apple2_deadtest_spec.rb`) and MOS6502 jump/stack tests (JSR/RTS nested) during development to verify the fixes, and those specs now succeed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969e6d14ae4832c980113e04cf8acee)