### PR TITLE
Add fast ISA-level 6502 simulator option for apple2 binary

### DIFF
--- a/examples/mos6502/bin/apple2
+++ b/examples/mos6502/bin/apple2
@@ -34,12 +34,18 @@ class Apple2Terminal
 
   def initialize(options = {})
     @options = options
-    @runner = Apple2Harness::Runner.new
+    # Use ISARunner for fast mode, HDL Runner for cycle-accurate mode
+    @runner = if options[:fast]
+                Apple2Harness::ISARunner.new
+              else
+                Apple2Harness::Runner.new
+              end
     @running = false
     @last_screen = nil
     @cycles_per_frame = options[:speed] || 10_000
     @debug = options[:debug] || false
     @green_screen = options[:green] || false
+    @fast_mode = options[:fast] || false
   end
 
   def load_rom(path, base_addr: 0xF800)
@@ -71,7 +77,8 @@ class Apple2Terminal
     trap('INT') { stop }
     trap('TERM') { stop }
 
-    puts "Starting Apple ][ emulator..."
+    mode = @fast_mode ? "ISA (fast)" : "HDL (cycle-accurate)"
+    puts "Starting Apple ][ emulator... [#{mode} mode]"
     puts "Press Ctrl+C to exit"
     puts "Press any key to continue..."
     sleep 0.5
@@ -359,7 +366,8 @@ options = {
   speed: 10_000,
   debug: false,
   green: false,
-  demo: false
+  demo: false,
+  fast: false
 }
 
 parser = OptionParser.new do |opts|
@@ -391,6 +399,10 @@ parser = OptionParser.new do |opts|
 
   opts.on("-g", "--green", "Green phosphor screen effect") do
     options[:green] = true
+  end
+
+  opts.on("-f", "--fast", "Use fast ISA-level simulator (not cycle-accurate)") do
+    options[:fast] = true
   end
 
   opts.on("--demo", "Run built-in demo program") do

--- a/examples/mos6502/utilities/isa_simulator.rb
+++ b/examples/mos6502/utilities/isa_simulator.rb
@@ -1,0 +1,645 @@
+# frozen_string_literal: true
+
+# MOS 6502 ISA-Level Simulator
+# Fast instruction-level simulator for performance-critical applications
+# Executes instructions directly without HDL simulation overhead
+
+module MOS6502
+  class ISASimulator
+    # Status flag bit positions
+    FLAG_C = 0  # Carry
+    FLAG_Z = 1  # Zero
+    FLAG_I = 2  # Interrupt Disable
+    FLAG_D = 3  # Decimal Mode
+    FLAG_B = 4  # Break
+    FLAG_U = 5  # Unused (always 1)
+    FLAG_V = 6  # Overflow
+    FLAG_N = 7  # Negative
+
+    # Interrupt vectors
+    NMI_VECTOR   = 0xFFFA
+    RESET_VECTOR = 0xFFFC
+    IRQ_VECTOR   = 0xFFFE
+
+    attr_reader :a, :x, :y, :sp, :pc, :p, :cycles, :halted
+    attr_accessor :memory
+
+    def initialize(memory = nil)
+      @memory = memory || Array.new(0x10000, 0)
+      reset
+    end
+
+    def reset
+      @a = 0
+      @x = 0
+      @y = 0
+      @sp = 0xFD
+      @p = 0x24  # Unused flag set, Interrupt disable set
+      @pc = read_word(RESET_VECTOR)
+      @cycles = 0
+      @halted = false
+    end
+
+    # Execute one instruction and return cycles taken
+    def step
+      return 0 if @halted
+
+      opcode = fetch_byte
+      execute(opcode)
+    end
+
+    # Execute multiple instructions
+    def run(max_instructions = 1000)
+      count = 0
+      while count < max_instructions && !@halted
+        step
+        count += 1
+      end
+      count
+    end
+
+    # Execute for a number of cycles (approximate - will complete current instruction)
+    def run_cycles(target_cycles)
+      start_cycles = @cycles
+      while (@cycles - start_cycles) < target_cycles && !@halted
+        step
+      end
+      @cycles - start_cycles
+    end
+
+    # Register accessors (write)
+    def a=(v); @a = v & 0xFF; end
+    def x=(v); @x = v & 0xFF; end
+    def y=(v); @y = v & 0xFF; end
+    def sp=(v); @sp = v & 0xFF; end
+    def pc=(v); @pc = v & 0xFFFF; end
+    def p=(v); @p = (v & 0xFF) | 0x20; end  # Unused flag always 1
+
+    # Flag accessors
+    def flag_c; (@p >> FLAG_C) & 1; end
+    def flag_z; (@p >> FLAG_Z) & 1; end
+    def flag_i; (@p >> FLAG_I) & 1; end
+    def flag_d; (@p >> FLAG_D) & 1; end
+    def flag_b; (@p >> FLAG_B) & 1; end
+    def flag_v; (@p >> FLAG_V) & 1; end
+    def flag_n; (@p >> FLAG_N) & 1; end
+
+    def set_flag(flag, value)
+      if value != 0
+        @p |= (1 << flag)
+      else
+        @p &= ~(1 << flag)
+      end
+    end
+
+    # Memory operations
+    def read(addr)
+      addr &= 0xFFFF
+      if @memory.is_a?(Array)
+        @memory[addr] || 0
+      else
+        @memory.read(addr)
+      end
+    end
+
+    def write(addr, value)
+      addr &= 0xFFFF
+      value &= 0xFF
+      if @memory.is_a?(Array)
+        @memory[addr] = value
+      else
+        @memory.write(addr, value)
+      end
+    end
+
+    def read_word(addr)
+      lo = read(addr)
+      hi = read(addr + 1)
+      (hi << 8) | lo
+    end
+
+    def load_program(bytes, addr = 0x8000)
+      bytes.each_with_index do |byte, i|
+        write(addr + i, byte)
+      end
+      # Set reset vector
+      write(RESET_VECTOR, addr & 0xFF)
+      write(RESET_VECTOR + 1, (addr >> 8) & 0xFF)
+    end
+
+    # State inspection
+    def state
+      {
+        a: @a, x: @x, y: @y, sp: @sp, pc: @pc, p: @p,
+        n: flag_n, v: flag_v, b: flag_b, d: flag_d,
+        i: flag_i, z: flag_z, c: flag_c,
+        cycles: @cycles, halted: @halted
+      }
+    end
+
+    def halted?
+      @halted
+    end
+
+    private
+
+    def fetch_byte
+      byte = read(@pc)
+      @pc = (@pc + 1) & 0xFFFF
+      byte
+    end
+
+    def fetch_word
+      lo = fetch_byte
+      hi = fetch_byte
+      (hi << 8) | lo
+    end
+
+    # Stack operations
+    def push_byte(value)
+      write(0x100 + @sp, value)
+      @sp = (@sp - 1) & 0xFF
+    end
+
+    def pull_byte
+      @sp = (@sp + 1) & 0xFF
+      read(0x100 + @sp)
+    end
+
+    def push_word(value)
+      push_byte((value >> 8) & 0xFF)
+      push_byte(value & 0xFF)
+    end
+
+    def pull_word
+      lo = pull_byte
+      hi = pull_byte
+      (hi << 8) | lo
+    end
+
+    # Flag helpers
+    def set_nz(value)
+      set_flag(FLAG_Z, (value & 0xFF) == 0 ? 1 : 0)
+      set_flag(FLAG_N, (value & 0x80) != 0 ? 1 : 0)
+      value & 0xFF
+    end
+
+    # Addressing modes - return address
+    def addr_immediate
+      addr = @pc
+      @pc = (@pc + 1) & 0xFFFF
+      addr
+    end
+
+    def addr_zero_page
+      fetch_byte
+    end
+
+    def addr_zero_page_x
+      (fetch_byte + @x) & 0xFF
+    end
+
+    def addr_zero_page_y
+      (fetch_byte + @y) & 0xFF
+    end
+
+    def addr_absolute
+      fetch_word
+    end
+
+    def addr_absolute_x(check_page_cross = true)
+      base = fetch_word
+      addr = (base + @x) & 0xFFFF
+      @cycles += 1 if check_page_cross && (base & 0xFF00) != (addr & 0xFF00)
+      addr
+    end
+
+    def addr_absolute_y(check_page_cross = true)
+      base = fetch_word
+      addr = (base + @y) & 0xFFFF
+      @cycles += 1 if check_page_cross && (base & 0xFF00) != (addr & 0xFF00)
+      addr
+    end
+
+    def addr_indirect
+      ptr = fetch_word
+      # 6502 indirect JMP bug: if ptr is at xxFF, high byte comes from xx00
+      lo = read(ptr)
+      hi_addr = (ptr & 0xFF) == 0xFF ? (ptr & 0xFF00) : (ptr + 1)
+      hi = read(hi_addr)
+      (hi << 8) | lo
+    end
+
+    def addr_indexed_indirect  # (zp,X)
+      ptr = (fetch_byte + @x) & 0xFF
+      lo = read(ptr)
+      hi = read((ptr + 1) & 0xFF)
+      (hi << 8) | lo
+    end
+
+    def addr_indirect_indexed(check_page_cross = true)  # (zp),Y
+      ptr = fetch_byte
+      lo = read(ptr)
+      hi = read((ptr + 1) & 0xFF)
+      base = (hi << 8) | lo
+      addr = (base + @y) & 0xFFFF
+      @cycles += 1 if check_page_cross && (base & 0xFF00) != (addr & 0xFF00)
+      addr
+    end
+
+    def addr_relative
+      offset = fetch_byte
+      offset = offset - 256 if offset > 127
+      (@pc + offset) & 0xFFFF
+    end
+
+    # ALU operations
+    def do_adc(value)
+      if flag_d == 1
+        # Decimal mode
+        lo = (@a & 0x0F) + (value & 0x0F) + flag_c
+        hi = (@a >> 4) + (value >> 4)
+        hi += 1 if lo > 9
+        lo -= 10 if lo > 9
+        hi += 1 if hi > 9
+        set_flag(FLAG_C, hi > 9 ? 1 : 0)
+        hi -= 10 if hi > 9
+        result = ((hi << 4) | (lo & 0x0F)) & 0xFF
+        set_flag(FLAG_Z, result == 0 ? 1 : 0)
+        set_flag(FLAG_N, (result & 0x80) != 0 ? 1 : 0)
+        # V flag in decimal mode is undefined on NMOS 6502
+        @a = result
+      else
+        # Binary mode
+        sum = @a + value + flag_c
+        overflow = (~(@a ^ value) & (@a ^ sum) & 0x80) != 0
+        set_flag(FLAG_C, sum > 0xFF ? 1 : 0)
+        set_flag(FLAG_V, overflow ? 1 : 0)
+        @a = set_nz(sum)
+      end
+    end
+
+    def do_sbc(value)
+      if flag_d == 1
+        # Decimal mode
+        lo = (@a & 0x0F) - (value & 0x0F) - (1 - flag_c)
+        hi = (@a >> 4) - (value >> 4)
+        if lo < 0
+          lo += 10
+          hi -= 1
+        end
+        if hi < 0
+          hi += 10
+          set_flag(FLAG_C, 0)
+        else
+          set_flag(FLAG_C, 1)
+        end
+        result = ((hi << 4) | (lo & 0x0F)) & 0xFF
+        set_flag(FLAG_Z, result == 0 ? 1 : 0)
+        set_flag(FLAG_N, (result & 0x80) != 0 ? 1 : 0)
+        @a = result
+      else
+        # Binary mode (SBC is ADC with inverted operand)
+        do_adc(value ^ 0xFF)
+      end
+    end
+
+    def do_cmp(reg_value, mem_value)
+      result = reg_value - mem_value
+      set_flag(FLAG_C, reg_value >= mem_value ? 1 : 0)
+      set_nz(result)
+    end
+
+    def do_asl(value)
+      set_flag(FLAG_C, (value & 0x80) != 0 ? 1 : 0)
+      set_nz(value << 1)
+    end
+
+    def do_lsr(value)
+      set_flag(FLAG_C, value & 1)
+      set_nz(value >> 1)
+    end
+
+    def do_rol(value)
+      carry = flag_c
+      set_flag(FLAG_C, (value & 0x80) != 0 ? 1 : 0)
+      set_nz((value << 1) | carry)
+    end
+
+    def do_ror(value)
+      carry = flag_c
+      set_flag(FLAG_C, value & 1)
+      set_nz((value >> 1) | (carry << 7))
+    end
+
+    # Branch helper
+    def branch_if(condition)
+      target = addr_relative
+      if condition
+        @cycles += 1
+        @cycles += 1 if (@pc & 0xFF00) != (target & 0xFF00)
+        @pc = target
+      end
+    end
+
+    # Main instruction executor
+    def execute(opcode)
+      case opcode
+      # ADC - Add with Carry
+      when 0x69 then @cycles += 2; do_adc(read(addr_immediate))
+      when 0x65 then @cycles += 3; do_adc(read(addr_zero_page))
+      when 0x75 then @cycles += 4; do_adc(read(addr_zero_page_x))
+      when 0x6D then @cycles += 4; do_adc(read(addr_absolute))
+      when 0x7D then @cycles += 4; do_adc(read(addr_absolute_x))
+      when 0x79 then @cycles += 4; do_adc(read(addr_absolute_y))
+      when 0x61 then @cycles += 6; do_adc(read(addr_indexed_indirect))
+      when 0x71 then @cycles += 5; do_adc(read(addr_indirect_indexed))
+
+      # SBC - Subtract with Carry
+      when 0xE9 then @cycles += 2; do_sbc(read(addr_immediate))
+      when 0xE5 then @cycles += 3; do_sbc(read(addr_zero_page))
+      when 0xF5 then @cycles += 4; do_sbc(read(addr_zero_page_x))
+      when 0xED then @cycles += 4; do_sbc(read(addr_absolute))
+      when 0xFD then @cycles += 4; do_sbc(read(addr_absolute_x))
+      when 0xF9 then @cycles += 4; do_sbc(read(addr_absolute_y))
+      when 0xE1 then @cycles += 6; do_sbc(read(addr_indexed_indirect))
+      when 0xF1 then @cycles += 5; do_sbc(read(addr_indirect_indexed))
+
+      # AND - Logical AND
+      when 0x29 then @cycles += 2; @a = set_nz(@a & read(addr_immediate))
+      when 0x25 then @cycles += 3; @a = set_nz(@a & read(addr_zero_page))
+      when 0x35 then @cycles += 4; @a = set_nz(@a & read(addr_zero_page_x))
+      when 0x2D then @cycles += 4; @a = set_nz(@a & read(addr_absolute))
+      when 0x3D then @cycles += 4; @a = set_nz(@a & read(addr_absolute_x))
+      when 0x39 then @cycles += 4; @a = set_nz(@a & read(addr_absolute_y))
+      when 0x21 then @cycles += 6; @a = set_nz(@a & read(addr_indexed_indirect))
+      when 0x31 then @cycles += 5; @a = set_nz(@a & read(addr_indirect_indexed))
+
+      # ORA - Logical OR
+      when 0x09 then @cycles += 2; @a = set_nz(@a | read(addr_immediate))
+      when 0x05 then @cycles += 3; @a = set_nz(@a | read(addr_zero_page))
+      when 0x15 then @cycles += 4; @a = set_nz(@a | read(addr_zero_page_x))
+      when 0x0D then @cycles += 4; @a = set_nz(@a | read(addr_absolute))
+      when 0x1D then @cycles += 4; @a = set_nz(@a | read(addr_absolute_x))
+      when 0x19 then @cycles += 4; @a = set_nz(@a | read(addr_absolute_y))
+      when 0x01 then @cycles += 6; @a = set_nz(@a | read(addr_indexed_indirect))
+      when 0x11 then @cycles += 5; @a = set_nz(@a | read(addr_indirect_indexed))
+
+      # EOR - Exclusive OR
+      when 0x49 then @cycles += 2; @a = set_nz(@a ^ read(addr_immediate))
+      when 0x45 then @cycles += 3; @a = set_nz(@a ^ read(addr_zero_page))
+      when 0x55 then @cycles += 4; @a = set_nz(@a ^ read(addr_zero_page_x))
+      when 0x4D then @cycles += 4; @a = set_nz(@a ^ read(addr_absolute))
+      when 0x5D then @cycles += 4; @a = set_nz(@a ^ read(addr_absolute_x))
+      when 0x59 then @cycles += 4; @a = set_nz(@a ^ read(addr_absolute_y))
+      when 0x41 then @cycles += 6; @a = set_nz(@a ^ read(addr_indexed_indirect))
+      when 0x51 then @cycles += 5; @a = set_nz(@a ^ read(addr_indirect_indexed))
+
+      # CMP - Compare Accumulator
+      when 0xC9 then @cycles += 2; do_cmp(@a, read(addr_immediate))
+      when 0xC5 then @cycles += 3; do_cmp(@a, read(addr_zero_page))
+      when 0xD5 then @cycles += 4; do_cmp(@a, read(addr_zero_page_x))
+      when 0xCD then @cycles += 4; do_cmp(@a, read(addr_absolute))
+      when 0xDD then @cycles += 4; do_cmp(@a, read(addr_absolute_x))
+      when 0xD9 then @cycles += 4; do_cmp(@a, read(addr_absolute_y))
+      when 0xC1 then @cycles += 6; do_cmp(@a, read(addr_indexed_indirect))
+      when 0xD1 then @cycles += 5; do_cmp(@a, read(addr_indirect_indexed))
+
+      # CPX - Compare X Register
+      when 0xE0 then @cycles += 2; do_cmp(@x, read(addr_immediate))
+      when 0xE4 then @cycles += 3; do_cmp(@x, read(addr_zero_page))
+      when 0xEC then @cycles += 4; do_cmp(@x, read(addr_absolute))
+
+      # CPY - Compare Y Register
+      when 0xC0 then @cycles += 2; do_cmp(@y, read(addr_immediate))
+      when 0xC4 then @cycles += 3; do_cmp(@y, read(addr_zero_page))
+      when 0xCC then @cycles += 4; do_cmp(@y, read(addr_absolute))
+
+      # BIT - Bit Test
+      when 0x24
+        @cycles += 3
+        value = read(addr_zero_page)
+        set_flag(FLAG_Z, (@a & value) == 0 ? 1 : 0)
+        set_flag(FLAG_N, (value & 0x80) != 0 ? 1 : 0)
+        set_flag(FLAG_V, (value & 0x40) != 0 ? 1 : 0)
+      when 0x2C
+        @cycles += 4
+        value = read(addr_absolute)
+        set_flag(FLAG_Z, (@a & value) == 0 ? 1 : 0)
+        set_flag(FLAG_N, (value & 0x80) != 0 ? 1 : 0)
+        set_flag(FLAG_V, (value & 0x40) != 0 ? 1 : 0)
+
+      # LDA - Load Accumulator
+      when 0xA9 then @cycles += 2; @a = set_nz(read(addr_immediate))
+      when 0xA5 then @cycles += 3; @a = set_nz(read(addr_zero_page))
+      when 0xB5 then @cycles += 4; @a = set_nz(read(addr_zero_page_x))
+      when 0xAD then @cycles += 4; @a = set_nz(read(addr_absolute))
+      when 0xBD then @cycles += 4; @a = set_nz(read(addr_absolute_x))
+      when 0xB9 then @cycles += 4; @a = set_nz(read(addr_absolute_y))
+      when 0xA1 then @cycles += 6; @a = set_nz(read(addr_indexed_indirect))
+      when 0xB1 then @cycles += 5; @a = set_nz(read(addr_indirect_indexed))
+
+      # LDX - Load X Register
+      when 0xA2 then @cycles += 2; @x = set_nz(read(addr_immediate))
+      when 0xA6 then @cycles += 3; @x = set_nz(read(addr_zero_page))
+      when 0xB6 then @cycles += 4; @x = set_nz(read(addr_zero_page_y))
+      when 0xAE then @cycles += 4; @x = set_nz(read(addr_absolute))
+      when 0xBE then @cycles += 4; @x = set_nz(read(addr_absolute_y))
+
+      # LDY - Load Y Register
+      when 0xA0 then @cycles += 2; @y = set_nz(read(addr_immediate))
+      when 0xA4 then @cycles += 3; @y = set_nz(read(addr_zero_page))
+      when 0xB4 then @cycles += 4; @y = set_nz(read(addr_zero_page_x))
+      when 0xAC then @cycles += 4; @y = set_nz(read(addr_absolute))
+      when 0xBC then @cycles += 4; @y = set_nz(read(addr_absolute_x))
+
+      # STA - Store Accumulator
+      when 0x85 then @cycles += 3; write(addr_zero_page, @a)
+      when 0x95 then @cycles += 4; write(addr_zero_page_x, @a)
+      when 0x8D then @cycles += 4; write(addr_absolute, @a)
+      when 0x9D then @cycles += 5; write(addr_absolute_x(false), @a)
+      when 0x99 then @cycles += 5; write(addr_absolute_y(false), @a)
+      when 0x81 then @cycles += 6; write(addr_indexed_indirect, @a)
+      when 0x91 then @cycles += 6; write(addr_indirect_indexed(false), @a)
+
+      # STX - Store X Register
+      when 0x86 then @cycles += 3; write(addr_zero_page, @x)
+      when 0x96 then @cycles += 4; write(addr_zero_page_y, @x)
+      when 0x8E then @cycles += 4; write(addr_absolute, @x)
+
+      # STY - Store Y Register
+      when 0x84 then @cycles += 3; write(addr_zero_page, @y)
+      when 0x94 then @cycles += 4; write(addr_zero_page_x, @y)
+      when 0x8C then @cycles += 4; write(addr_absolute, @y)
+
+      # Register Transfers
+      when 0xAA then @cycles += 2; @x = set_nz(@a)  # TAX
+      when 0x8A then @cycles += 2; @a = set_nz(@x)  # TXA
+      when 0xA8 then @cycles += 2; @y = set_nz(@a)  # TAY
+      when 0x98 then @cycles += 2; @a = set_nz(@y)  # TYA
+      when 0xBA then @cycles += 2; @x = set_nz(@sp) # TSX
+      when 0x9A then @cycles += 2; @sp = @x        # TXS (doesn't affect flags)
+
+      # Increment/Decrement Register
+      when 0xE8 then @cycles += 2; @x = set_nz(@x + 1)  # INX
+      when 0xCA then @cycles += 2; @x = set_nz(@x - 1)  # DEX
+      when 0xC8 then @cycles += 2; @y = set_nz(@y + 1)  # INY
+      when 0x88 then @cycles += 2; @y = set_nz(@y - 1)  # DEY
+
+      # Increment Memory
+      when 0xE6
+        @cycles += 5; addr = addr_zero_page
+        write(addr, set_nz(read(addr) + 1))
+      when 0xF6
+        @cycles += 6; addr = addr_zero_page_x
+        write(addr, set_nz(read(addr) + 1))
+      when 0xEE
+        @cycles += 6; addr = addr_absolute
+        write(addr, set_nz(read(addr) + 1))
+      when 0xFE
+        @cycles += 7; addr = addr_absolute_x(false)
+        write(addr, set_nz(read(addr) + 1))
+
+      # Decrement Memory
+      when 0xC6
+        @cycles += 5; addr = addr_zero_page
+        write(addr, set_nz(read(addr) - 1))
+      when 0xD6
+        @cycles += 6; addr = addr_zero_page_x
+        write(addr, set_nz(read(addr) - 1))
+      when 0xCE
+        @cycles += 6; addr = addr_absolute
+        write(addr, set_nz(read(addr) - 1))
+      when 0xDE
+        @cycles += 7; addr = addr_absolute_x(false)
+        write(addr, set_nz(read(addr) - 1))
+
+      # ASL - Arithmetic Shift Left
+      when 0x0A then @cycles += 2; @a = do_asl(@a)
+      when 0x06
+        @cycles += 5; addr = addr_zero_page
+        write(addr, do_asl(read(addr)))
+      when 0x16
+        @cycles += 6; addr = addr_zero_page_x
+        write(addr, do_asl(read(addr)))
+      when 0x0E
+        @cycles += 6; addr = addr_absolute
+        write(addr, do_asl(read(addr)))
+      when 0x1E
+        @cycles += 7; addr = addr_absolute_x(false)
+        write(addr, do_asl(read(addr)))
+
+      # LSR - Logical Shift Right
+      when 0x4A then @cycles += 2; @a = do_lsr(@a)
+      when 0x46
+        @cycles += 5; addr = addr_zero_page
+        write(addr, do_lsr(read(addr)))
+      when 0x56
+        @cycles += 6; addr = addr_zero_page_x
+        write(addr, do_lsr(read(addr)))
+      when 0x4E
+        @cycles += 6; addr = addr_absolute
+        write(addr, do_lsr(read(addr)))
+      when 0x5E
+        @cycles += 7; addr = addr_absolute_x(false)
+        write(addr, do_lsr(read(addr)))
+
+      # ROL - Rotate Left
+      when 0x2A then @cycles += 2; @a = do_rol(@a)
+      when 0x26
+        @cycles += 5; addr = addr_zero_page
+        write(addr, do_rol(read(addr)))
+      when 0x36
+        @cycles += 6; addr = addr_zero_page_x
+        write(addr, do_rol(read(addr)))
+      when 0x2E
+        @cycles += 6; addr = addr_absolute
+        write(addr, do_rol(read(addr)))
+      when 0x3E
+        @cycles += 7; addr = addr_absolute_x(false)
+        write(addr, do_rol(read(addr)))
+
+      # ROR - Rotate Right
+      when 0x6A then @cycles += 2; @a = do_ror(@a)
+      when 0x66
+        @cycles += 5; addr = addr_zero_page
+        write(addr, do_ror(read(addr)))
+      when 0x76
+        @cycles += 6; addr = addr_zero_page_x
+        write(addr, do_ror(read(addr)))
+      when 0x6E
+        @cycles += 6; addr = addr_absolute
+        write(addr, do_ror(read(addr)))
+      when 0x7E
+        @cycles += 7; addr = addr_absolute_x(false)
+        write(addr, do_ror(read(addr)))
+
+      # Branches
+      when 0x10 then @cycles += 2; branch_if(flag_n == 0)  # BPL
+      when 0x30 then @cycles += 2; branch_if(flag_n == 1)  # BMI
+      when 0x50 then @cycles += 2; branch_if(flag_v == 0)  # BVC
+      when 0x70 then @cycles += 2; branch_if(flag_v == 1)  # BVS
+      when 0x90 then @cycles += 2; branch_if(flag_c == 0)  # BCC
+      when 0xB0 then @cycles += 2; branch_if(flag_c == 1)  # BCS
+      when 0xD0 then @cycles += 2; branch_if(flag_z == 0)  # BNE
+      when 0xF0 then @cycles += 2; branch_if(flag_z == 1)  # BEQ
+
+      # JMP - Jump
+      when 0x4C then @cycles += 3; @pc = addr_absolute
+      when 0x6C then @cycles += 5; @pc = addr_indirect
+
+      # JSR - Jump to Subroutine
+      when 0x20
+        @cycles += 6
+        target = addr_absolute
+        push_word(@pc - 1)
+        @pc = target
+
+      # RTS - Return from Subroutine
+      when 0x60
+        @cycles += 6
+        @pc = (pull_word + 1) & 0xFFFF
+
+      # RTI - Return from Interrupt
+      when 0x40
+        @cycles += 6
+        @p = pull_byte | 0x20  # Unused flag always 1
+        @pc = pull_word
+
+      # Stack Operations
+      when 0x48 then @cycles += 3; push_byte(@a)  # PHA
+      when 0x08 then @cycles += 3; push_byte(@p | 0x10)  # PHP (B flag set when pushed)
+      when 0x68 then @cycles += 4; @a = set_nz(pull_byte)  # PLA
+      when 0x28 then @cycles += 4; @p = pull_byte | 0x20  # PLP
+
+      # Flag Operations
+      when 0x18 then @cycles += 2; set_flag(FLAG_C, 0)  # CLC
+      when 0x38 then @cycles += 2; set_flag(FLAG_C, 1)  # SEC
+      when 0x58 then @cycles += 2; set_flag(FLAG_I, 0)  # CLI
+      when 0x78 then @cycles += 2; set_flag(FLAG_I, 1)  # SEI
+      when 0xB8 then @cycles += 2; set_flag(FLAG_V, 0)  # CLV
+      when 0xD8 then @cycles += 2; set_flag(FLAG_D, 0)  # CLD
+      when 0xF8 then @cycles += 2; set_flag(FLAG_D, 1)  # SED
+
+      # NOP
+      when 0xEA then @cycles += 2
+
+      # BRK - Break
+      when 0x00
+        @cycles += 7
+        @pc = (@pc + 1) & 0xFFFF  # BRK skips a byte
+        push_word(@pc)
+        push_byte(@p | 0x10)  # B flag set when pushed
+        set_flag(FLAG_I, 1)
+        @pc = read_word(IRQ_VECTOR)
+
+      else
+        # Illegal opcode - halt
+        @halted = true
+        @cycles += 2
+      end
+
+      @cycles
+    end
+  end
+end

--- a/spec/examples/mos6502/utilities/isa_simulator_spec.rb
+++ b/spec/examples/mos6502/utilities/isa_simulator_spec.rb
@@ -1,0 +1,946 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require_relative '../../../../lib/rhdl'
+require_relative '../../../../examples/mos6502/utilities/isa_simulator'
+require_relative '../../../../examples/mos6502/utilities/assembler'
+
+RSpec.describe MOS6502::ISASimulator do
+  let(:sim) { MOS6502::ISASimulator.new }
+  let(:asm) { MOS6502::Assembler.new }
+
+  def assemble_and_load(source, addr = 0x8000)
+    bytes = asm.assemble(source, addr)
+    sim.load_program(bytes, addr)
+    sim.reset
+    bytes
+  end
+
+  describe 'initialization' do
+    it 'initializes with default values' do
+      expect(sim.a).to eq(0)
+      expect(sim.x).to eq(0)
+      expect(sim.y).to eq(0)
+      expect(sim.sp).to eq(0xFD)
+      expect(sim.halted?).to be false
+    end
+
+    it 'has interrupt flag set after reset' do
+      expect(sim.flag_i).to eq(1)
+    end
+  end
+
+  describe 'load instructions' do
+    describe 'LDA' do
+      it 'LDA immediate' do
+        assemble_and_load('LDA #$42')
+        sim.step
+        expect(sim.a).to eq(0x42)
+      end
+
+      it 'LDA zero page' do
+        sim.write(0x10, 0x55)
+        assemble_and_load('LDA $10')
+        sim.step
+        expect(sim.a).to eq(0x55)
+      end
+
+      it 'LDA zero page,X' do
+        sim.write(0x15, 0x77)
+        assemble_and_load(<<~'ASM')
+          LDX #$05
+          LDA $10,X
+        ASM
+        2.times { sim.step }
+        expect(sim.a).to eq(0x77)
+      end
+
+      it 'LDA absolute' do
+        sim.write(0x1234, 0x88)
+        assemble_and_load('LDA $1234')
+        sim.step
+        expect(sim.a).to eq(0x88)
+      end
+
+      it 'LDA absolute,X' do
+        sim.write(0x1239, 0x99)
+        assemble_and_load(<<~'ASM')
+          LDX #$05
+          LDA $1234,X
+        ASM
+        2.times { sim.step }
+        expect(sim.a).to eq(0x99)
+      end
+
+      it 'LDA absolute,Y' do
+        sim.write(0x123A, 0xAA)
+        assemble_and_load(<<~'ASM')
+          LDY #$06
+          LDA $1234,Y
+        ASM
+        2.times { sim.step }
+        expect(sim.a).to eq(0xAA)
+      end
+
+      it 'LDA (indirect,X)' do
+        sim.write(0x15, 0x00)
+        sim.write(0x16, 0x20)
+        sim.write(0x2000, 0xBB)
+        assemble_and_load(<<~'ASM')
+          LDX #$05
+          LDA ($10,X)
+        ASM
+        2.times { sim.step }
+        expect(sim.a).to eq(0xBB)
+      end
+
+      it 'LDA (indirect),Y' do
+        sim.write(0x10, 0x00)
+        sim.write(0x11, 0x20)
+        sim.write(0x2005, 0xCC)
+        assemble_and_load(<<~'ASM')
+          LDY #$05
+          LDA ($10),Y
+        ASM
+        2.times { sim.step }
+        expect(sim.a).to eq(0xCC)
+      end
+
+      it 'sets Z flag when loading zero' do
+        assemble_and_load('LDA #$00')
+        sim.step
+        expect(sim.flag_z).to eq(1)
+      end
+
+      it 'sets N flag when loading negative' do
+        assemble_and_load('LDA #$80')
+        sim.step
+        expect(sim.flag_n).to eq(1)
+      end
+    end
+
+    describe 'LDX' do
+      it 'LDX immediate' do
+        assemble_and_load('LDX #$42')
+        sim.step
+        expect(sim.x).to eq(0x42)
+      end
+
+      it 'LDX zero page' do
+        sim.write(0x10, 0x55)
+        assemble_and_load('LDX $10')
+        sim.step
+        expect(sim.x).to eq(0x55)
+      end
+
+      it 'LDX zero page,Y' do
+        sim.write(0x15, 0x77)
+        assemble_and_load(<<~'ASM')
+          LDY #$05
+          LDX $10,Y
+        ASM
+        2.times { sim.step }
+        expect(sim.x).to eq(0x77)
+      end
+    end
+
+    describe 'LDY' do
+      it 'LDY immediate' do
+        assemble_and_load('LDY #$42')
+        sim.step
+        expect(sim.y).to eq(0x42)
+      end
+
+      it 'LDY zero page' do
+        sim.write(0x10, 0x55)
+        assemble_and_load('LDY $10')
+        sim.step
+        expect(sim.y).to eq(0x55)
+      end
+    end
+  end
+
+  describe 'store instructions' do
+    describe 'STA' do
+      it 'STA zero page' do
+        assemble_and_load(<<~'ASM')
+          LDA #$42
+          STA $10
+        ASM
+        2.times { sim.step }
+        expect(sim.read(0x10)).to eq(0x42)
+      end
+
+      it 'STA absolute' do
+        assemble_and_load(<<~'ASM')
+          LDA #$55
+          STA $1234
+        ASM
+        2.times { sim.step }
+        expect(sim.read(0x1234)).to eq(0x55)
+      end
+    end
+
+    describe 'STX' do
+      it 'STX zero page' do
+        assemble_and_load(<<~'ASM')
+          LDX #$42
+          STX $10
+        ASM
+        2.times { sim.step }
+        expect(sim.read(0x10)).to eq(0x42)
+      end
+    end
+
+    describe 'STY' do
+      it 'STY zero page' do
+        assemble_and_load(<<~'ASM')
+          LDY #$42
+          STY $10
+        ASM
+        2.times { sim.step }
+        expect(sim.read(0x10)).to eq(0x42)
+      end
+    end
+  end
+
+  describe 'transfer instructions' do
+    it 'TAX' do
+      assemble_and_load(<<~'ASM')
+        LDA #$42
+        TAX
+      ASM
+      2.times { sim.step }
+      expect(sim.x).to eq(0x42)
+    end
+
+    it 'TXA' do
+      assemble_and_load(<<~'ASM')
+        LDX #$42
+        TXA
+      ASM
+      2.times { sim.step }
+      expect(sim.a).to eq(0x42)
+    end
+
+    it 'TAY' do
+      assemble_and_load(<<~'ASM')
+        LDA #$42
+        TAY
+      ASM
+      2.times { sim.step }
+      expect(sim.y).to eq(0x42)
+    end
+
+    it 'TYA' do
+      assemble_and_load(<<~'ASM')
+        LDY #$42
+        TYA
+      ASM
+      2.times { sim.step }
+      expect(sim.a).to eq(0x42)
+    end
+
+    it 'TSX' do
+      assemble_and_load('TSX')
+      sim.step
+      expect(sim.x).to eq(0xFD)  # Initial SP value
+    end
+
+    it 'TXS' do
+      assemble_and_load(<<~'ASM')
+        LDX #$FF
+        TXS
+      ASM
+      2.times { sim.step }
+      expect(sim.sp).to eq(0xFF)
+    end
+  end
+
+  describe 'arithmetic instructions' do
+    describe 'ADC' do
+      it 'adds without carry' do
+        assemble_and_load(<<~'ASM')
+          CLC
+          LDA #$10
+          ADC #$20
+        ASM
+        3.times { sim.step }
+        expect(sim.a).to eq(0x30)
+        expect(sim.flag_c).to eq(0)
+      end
+
+      it 'adds with carry in' do
+        assemble_and_load(<<~'ASM')
+          SEC
+          LDA #$10
+          ADC #$20
+        ASM
+        3.times { sim.step }
+        expect(sim.a).to eq(0x31)
+      end
+
+      it 'sets carry on overflow' do
+        assemble_and_load(<<~'ASM')
+          CLC
+          LDA #$FF
+          ADC #$01
+        ASM
+        3.times { sim.step }
+        expect(sim.a).to eq(0x00)
+        expect(sim.flag_c).to eq(1)
+        expect(sim.flag_z).to eq(1)
+      end
+
+      it 'sets overflow flag correctly' do
+        assemble_and_load(<<~'ASM')
+          CLC
+          LDA #$7F
+          ADC #$01
+        ASM
+        3.times { sim.step }
+        expect(sim.a).to eq(0x80)
+        expect(sim.flag_v).to eq(1)
+        expect(sim.flag_n).to eq(1)
+      end
+    end
+
+    describe 'SBC' do
+      it 'subtracts with borrow' do
+        assemble_and_load(<<~'ASM')
+          SEC
+          LDA #$30
+          SBC #$10
+        ASM
+        3.times { sim.step }
+        expect(sim.a).to eq(0x20)
+        expect(sim.flag_c).to eq(1)
+      end
+
+      it 'subtracts with borrow in' do
+        assemble_and_load(<<~'ASM')
+          CLC
+          LDA #$30
+          SBC #$10
+        ASM
+        3.times { sim.step }
+        expect(sim.a).to eq(0x1F)
+      end
+
+      it 'clears carry on underflow' do
+        assemble_and_load(<<~'ASM')
+          SEC
+          LDA #$00
+          SBC #$01
+        ASM
+        3.times { sim.step }
+        expect(sim.a).to eq(0xFF)
+        expect(sim.flag_c).to eq(0)
+      end
+    end
+  end
+
+  describe 'logical instructions' do
+    describe 'AND' do
+      it 'performs logical AND' do
+        assemble_and_load(<<~'ASM')
+          LDA #$FF
+          AND #$0F
+        ASM
+        2.times { sim.step }
+        expect(sim.a).to eq(0x0F)
+      end
+    end
+
+    describe 'ORA' do
+      it 'performs logical OR' do
+        assemble_and_load(<<~'ASM')
+          LDA #$F0
+          ORA #$0F
+        ASM
+        2.times { sim.step }
+        expect(sim.a).to eq(0xFF)
+      end
+    end
+
+    describe 'EOR' do
+      it 'performs logical XOR' do
+        assemble_and_load(<<~'ASM')
+          LDA #$FF
+          EOR #$0F
+        ASM
+        2.times { sim.step }
+        expect(sim.a).to eq(0xF0)
+      end
+    end
+  end
+
+  describe 'compare instructions' do
+    describe 'CMP' do
+      it 'sets carry when A >= M' do
+        assemble_and_load(<<~'ASM')
+          LDA #$50
+          CMP #$40
+        ASM
+        2.times { sim.step }
+        expect(sim.flag_c).to eq(1)
+        expect(sim.flag_z).to eq(0)
+      end
+
+      it 'sets zero when A == M' do
+        assemble_and_load(<<~'ASM')
+          LDA #$50
+          CMP #$50
+        ASM
+        2.times { sim.step }
+        expect(sim.flag_c).to eq(1)
+        expect(sim.flag_z).to eq(1)
+      end
+
+      it 'clears carry when A < M' do
+        assemble_and_load(<<~'ASM')
+          LDA #$40
+          CMP #$50
+        ASM
+        2.times { sim.step }
+        expect(sim.flag_c).to eq(0)
+      end
+    end
+
+    describe 'CPX' do
+      it 'compares X register' do
+        assemble_and_load(<<~'ASM')
+          LDX #$50
+          CPX #$50
+        ASM
+        2.times { sim.step }
+        expect(sim.flag_z).to eq(1)
+        expect(sim.flag_c).to eq(1)
+      end
+    end
+
+    describe 'CPY' do
+      it 'compares Y register' do
+        assemble_and_load(<<~'ASM')
+          LDY #$50
+          CPY #$50
+        ASM
+        2.times { sim.step }
+        expect(sim.flag_z).to eq(1)
+        expect(sim.flag_c).to eq(1)
+      end
+    end
+  end
+
+  describe 'increment/decrement instructions' do
+    describe 'INX' do
+      it 'increments X' do
+        assemble_and_load(<<~'ASM')
+          LDX #$10
+          INX
+        ASM
+        2.times { sim.step }
+        expect(sim.x).to eq(0x11)
+      end
+
+      it 'wraps from FF to 00' do
+        assemble_and_load(<<~'ASM')
+          LDX #$FF
+          INX
+        ASM
+        2.times { sim.step }
+        expect(sim.x).to eq(0x00)
+        expect(sim.flag_z).to eq(1)
+      end
+    end
+
+    describe 'DEX' do
+      it 'decrements X' do
+        assemble_and_load(<<~'ASM')
+          LDX #$10
+          DEX
+        ASM
+        2.times { sim.step }
+        expect(sim.x).to eq(0x0F)
+      end
+
+      it 'wraps from 00 to FF' do
+        assemble_and_load(<<~'ASM')
+          LDX #$00
+          DEX
+        ASM
+        2.times { sim.step }
+        expect(sim.x).to eq(0xFF)
+        expect(sim.flag_n).to eq(1)
+      end
+    end
+
+    describe 'INY' do
+      it 'increments Y' do
+        assemble_and_load(<<~'ASM')
+          LDY #$10
+          INY
+        ASM
+        2.times { sim.step }
+        expect(sim.y).to eq(0x11)
+      end
+    end
+
+    describe 'DEY' do
+      it 'decrements Y' do
+        assemble_and_load(<<~'ASM')
+          LDY #$10
+          DEY
+        ASM
+        2.times { sim.step }
+        expect(sim.y).to eq(0x0F)
+      end
+    end
+
+    describe 'INC' do
+      it 'increments memory' do
+        sim.write(0x10, 0x42)
+        assemble_and_load('INC $10')
+        sim.step
+        expect(sim.read(0x10)).to eq(0x43)
+      end
+    end
+
+    describe 'DEC' do
+      it 'decrements memory' do
+        sim.write(0x10, 0x42)
+        assemble_and_load('DEC $10')
+        sim.step
+        expect(sim.read(0x10)).to eq(0x41)
+      end
+    end
+  end
+
+  describe 'shift/rotate instructions' do
+    describe 'ASL' do
+      it 'shifts accumulator left' do
+        assemble_and_load(<<~'ASM')
+          LDA #$55
+          ASL A
+        ASM
+        2.times { sim.step }
+        expect(sim.a).to eq(0xAA)
+        expect(sim.flag_c).to eq(0)
+      end
+
+      it 'sets carry from bit 7' do
+        assemble_and_load(<<~'ASM')
+          LDA #$80
+          ASL A
+        ASM
+        2.times { sim.step }
+        expect(sim.a).to eq(0x00)
+        expect(sim.flag_c).to eq(1)
+        expect(sim.flag_z).to eq(1)
+      end
+    end
+
+    describe 'LSR' do
+      it 'shifts accumulator right' do
+        assemble_and_load(<<~'ASM')
+          LDA #$AA
+          LSR A
+        ASM
+        2.times { sim.step }
+        expect(sim.a).to eq(0x55)
+        expect(sim.flag_c).to eq(0)
+      end
+
+      it 'sets carry from bit 0' do
+        assemble_and_load(<<~'ASM')
+          LDA #$01
+          LSR A
+        ASM
+        2.times { sim.step }
+        expect(sim.a).to eq(0x00)
+        expect(sim.flag_c).to eq(1)
+        expect(sim.flag_z).to eq(1)
+      end
+    end
+
+    describe 'ROL' do
+      it 'rotates left through carry' do
+        assemble_and_load(<<~'ASM')
+          SEC
+          LDA #$55
+          ROL A
+        ASM
+        3.times { sim.step }
+        expect(sim.a).to eq(0xAB)
+        expect(sim.flag_c).to eq(0)
+      end
+    end
+
+    describe 'ROR' do
+      it 'rotates right through carry' do
+        assemble_and_load(<<~'ASM')
+          SEC
+          LDA #$AA
+          ROR A
+        ASM
+        3.times { sim.step }
+        expect(sim.a).to eq(0xD5)
+        expect(sim.flag_c).to eq(0)
+      end
+    end
+  end
+
+  describe 'branch instructions' do
+    it 'BEQ branches when zero' do
+      assemble_and_load(<<~'ASM')
+        LDA #$00
+        BEQ skip
+        LDA #$FF
+      skip:
+        NOP
+      ASM
+      3.times { sim.step }
+      expect(sim.a).to eq(0x00)
+    end
+
+    it 'BNE branches when not zero' do
+      assemble_and_load(<<~'ASM')
+        LDA #$01
+        BNE skip
+        LDA #$FF
+      skip:
+        NOP
+      ASM
+      3.times { sim.step }
+      expect(sim.a).to eq(0x01)
+    end
+
+    it 'BCS branches when carry set' do
+      assemble_and_load(<<~'ASM')
+        SEC
+        BCS skip
+        LDA #$FF
+      skip:
+        NOP
+      ASM
+      3.times { sim.step }
+      expect(sim.a).to eq(0x00)
+    end
+
+    it 'BCC branches when carry clear' do
+      assemble_and_load(<<~'ASM')
+        CLC
+        BCC skip
+        LDA #$FF
+      skip:
+        NOP
+      ASM
+      3.times { sim.step }
+      expect(sim.a).to eq(0x00)
+    end
+
+    it 'BMI branches when negative' do
+      assemble_and_load(<<~'ASM')
+        LDA #$80
+        BMI skip
+        LDA #$FF
+      skip:
+        NOP
+      ASM
+      3.times { sim.step }
+      expect(sim.a).to eq(0x80)
+    end
+
+    it 'BPL branches when positive' do
+      assemble_and_load(<<~'ASM')
+        LDA #$01
+        BPL skip
+        LDA #$FF
+      skip:
+        NOP
+      ASM
+      3.times { sim.step }
+      expect(sim.a).to eq(0x01)
+    end
+  end
+
+  describe 'jump instructions' do
+    it 'JMP absolute' do
+      assemble_and_load(<<~'ASM')
+        JMP skip
+        LDA #$FF
+      skip:
+        LDA #$42
+      ASM
+      2.times { sim.step }
+      expect(sim.a).to eq(0x42)
+    end
+
+    it 'JSR and RTS' do
+      assemble_and_load(<<~'ASM')
+        JSR sub
+        LDA #$42
+        JMP done
+      sub:
+        LDX #$FF
+        RTS
+      done:
+        NOP
+      ASM
+      5.times { sim.step }
+      expect(sim.x).to eq(0xFF)
+      expect(sim.a).to eq(0x42)
+    end
+  end
+
+  describe 'stack instructions' do
+    it 'PHA and PLA' do
+      assemble_and_load(<<~'ASM')
+        LDA #$42
+        PHA
+        LDA #$00
+        PLA
+      ASM
+      4.times { sim.step }
+      expect(sim.a).to eq(0x42)
+    end
+
+    it 'PHP and PLP' do
+      assemble_and_load(<<~'ASM')
+        SEC
+        PHP
+        CLC
+        PLP
+      ASM
+      4.times { sim.step }
+      expect(sim.flag_c).to eq(1)
+    end
+  end
+
+  describe 'flag instructions' do
+    it 'CLC clears carry' do
+      assemble_and_load(<<~'ASM')
+        SEC
+        CLC
+      ASM
+      2.times { sim.step }
+      expect(sim.flag_c).to eq(0)
+    end
+
+    it 'SEC sets carry' do
+      assemble_and_load(<<~'ASM')
+        CLC
+        SEC
+      ASM
+      2.times { sim.step }
+      expect(sim.flag_c).to eq(1)
+    end
+
+    it 'CLD clears decimal' do
+      assemble_and_load(<<~'ASM')
+        SED
+        CLD
+      ASM
+      2.times { sim.step }
+      expect(sim.flag_d).to eq(0)
+    end
+
+    it 'SED sets decimal' do
+      assemble_and_load(<<~'ASM')
+        CLD
+        SED
+      ASM
+      2.times { sim.step }
+      expect(sim.flag_d).to eq(1)
+    end
+
+    it 'CLI clears interrupt' do
+      assemble_and_load(<<~'ASM')
+        SEI
+        CLI
+      ASM
+      2.times { sim.step }
+      expect(sim.flag_i).to eq(0)
+    end
+
+    it 'SEI sets interrupt' do
+      assemble_and_load(<<~'ASM')
+        CLI
+        SEI
+      ASM
+      2.times { sim.step }
+      expect(sim.flag_i).to eq(1)
+    end
+
+    it 'CLV clears overflow' do
+      # Set V flag via ADC overflow then clear it
+      assemble_and_load(<<~'ASM')
+        CLC
+        LDA #$7F
+        ADC #$01
+        CLV
+      ASM
+      4.times { sim.step }
+      expect(sim.flag_v).to eq(0)
+    end
+  end
+
+  describe 'BIT instruction' do
+    it 'sets Z based on A AND M' do
+      sim.write(0x10, 0xF0)
+      assemble_and_load(<<~'ASM')
+        LDA #$0F
+        BIT $10
+      ASM
+      2.times { sim.step }
+      expect(sim.flag_z).to eq(1)
+    end
+
+    it 'sets N from bit 7 of memory' do
+      sim.write(0x10, 0x80)
+      assemble_and_load(<<~'ASM')
+        LDA #$FF
+        BIT $10
+      ASM
+      2.times { sim.step }
+      expect(sim.flag_n).to eq(1)
+    end
+
+    it 'sets V from bit 6 of memory' do
+      sim.write(0x10, 0x40)
+      assemble_and_load(<<~'ASM')
+        LDA #$FF
+        BIT $10
+      ASM
+      2.times { sim.step }
+      expect(sim.flag_v).to eq(1)
+    end
+  end
+
+  describe 'algorithms' do
+    it 'computes factorial of 5' do
+      assemble_and_load(<<~'ASM')
+        LDA #$05     ; n = 5
+        STA $10      ; store n
+        LDA #$01     ; result = 1
+        STA $11
+      loop:
+        LDA $10      ; load n
+        BEQ done     ; if n == 0, done
+        ; multiply result by n (simple loop addition)
+        LDX $10      ; x = n
+        LDA #$00     ; product = 0
+        STA $12
+      mult:
+        CLC
+        LDA $12
+        ADC $11      ; add result
+        STA $12
+        DEX
+        BNE mult
+        LDA $12
+        STA $11      ; result = product
+        DEC $10      ; n--
+        JMP loop
+      done:
+        NOP
+      ASM
+      sim.run(200)
+      # 5! = 120
+      expect(sim.read(0x11)).to eq(120)
+    end
+
+    it 'computes fibonacci(10)' do
+      # Compute fib(10) = 55
+      assemble_and_load(<<~'ASM')
+        LDA #$00     ; fib(0) = 0
+        STA $10
+        LDA #$01     ; fib(1) = 1
+        STA $11
+        LDX #$09     ; counter = 9 (we compute 9 more terms)
+      loop:
+        CLC
+        LDA $10
+        ADC $11      ; fib(n) = fib(n-1) + fib(n-2)
+        STA $12      ; temp = new value
+        LDA $11
+        STA $10      ; shift values
+        LDA $12
+        STA $11
+        DEX
+        BNE loop
+        NOP
+      ASM
+      sim.run(200)
+      expect(sim.read(0x11)).to eq(55)
+    end
+  end
+
+  describe 'run methods' do
+    it 'step returns cycles' do
+      assemble_and_load('LDA #$42')
+      cycles = sim.step
+      expect(cycles).to be > 0
+    end
+
+    it 'run executes multiple instructions' do
+      assemble_and_load(<<~'ASM')
+        LDA #$01
+        LDA #$02
+        LDA #$03
+        LDA #$04
+      ASM
+      count = sim.run(4)
+      expect(count).to eq(4)
+      expect(sim.a).to eq(0x04)
+    end
+
+    it 'run_cycles executes for approximate cycles' do
+      assemble_and_load(<<~'ASM')
+        LDA #$01
+        LDA #$02
+        LDA #$03
+        LDA #$04
+        LDA #$05
+      ASM
+      cycles = sim.run_cycles(10)
+      expect(cycles).to be >= 10
+    end
+  end
+
+  describe 'indirect JMP bug' do
+    it 'replicates 6502 page boundary bug' do
+      # When JMP ($xxFF), the high byte comes from $xx00 not $xx00+1
+      sim.write(0x20FF, 0x00)
+      sim.write(0x2000, 0x80)  # Bug: high byte from $2000, not $2100
+      sim.write(0x2100, 0xFF)  # This would be used on correct behavior
+
+      assemble_and_load('JMP ($20FF)')
+      sim.step
+      # Due to bug, jumps to $8000, not $FF00
+      expect(sim.pc).to eq(0x8000)
+    end
+  end
+
+  describe 'cycle counting' do
+    it 'counts cycles for instructions' do
+      assemble_and_load('LDA #$42')
+      start_cycles = sim.cycles
+      sim.step
+      expect(sim.cycles - start_cycles).to eq(2)
+    end
+
+    it 'adds page crossing cycle for indexed addressing' do
+      sim.write(0x1100, 0x42)  # Target is at $1000 + $FF + 1 = $1100 (crosses page)
+      assemble_and_load(<<~'ASM')
+        LDX #$FF
+        LDA $1001,X
+      ASM
+      sim.step  # LDX: 2 cycles
+      start_cycles = sim.cycles
+      sim.step  # LDA abs,X with page cross: 4 base + 1 page cross = 5 cycles
+      cycles_taken = sim.cycles - start_cycles
+      expect(cycles_taken).to eq(5)
+    end
+  end
+end


### PR DESCRIPTION
- Add ISASimulator class that executes 6502 instructions directly
  without HDL simulation overhead for better performance
- Add ISARunner to apple2_harness with same interface as HDL Runner
- Add --fast flag to apple2 binary to use ISA simulator
- Add text page methods to Apple2Bus for screen reading
- Add comprehensive tests for ISA simulator (84 test cases)