### PR TITLE
Add comprehensive CPU Verilog program execution tests

### DIFF
--- a/lib/rhdl/export/behavior/ir.rb
+++ b/lib/rhdl/export/behavior/ir.rb
@@ -5,10 +5,10 @@ module RHDL
     module IR
       class ModuleDef
         attr_reader :name, :ports, :nets, :regs, :assigns, :processes, :reg_ports, :instances,
-                    :memories, :write_ports
+                    :memories, :write_ports, :parameters
 
         def initialize(name:, ports:, nets:, regs:, assigns:, processes:, reg_ports: [], instances: [],
-                       memories: [], write_ports: [])
+                       memories: [], write_ports: [], parameters: {})
           @name = name
           @ports = ports
           @nets = nets
@@ -19,16 +19,18 @@ module RHDL
           @instances = instances
           @memories = memories
           @write_ports = write_ports
+          @parameters = parameters
         end
       end
 
       class Port
-        attr_reader :name, :direction, :width
+        attr_reader :name, :direction, :width, :default
 
-        def initialize(name:, direction:, width:)
+        def initialize(name:, direction:, width:, default: nil)
           @name = name
           @direction = direction
           @width = width
+          @default = default
         end
       end
 

--- a/lib/rhdl/hdl/arithmetic/alu.rb
+++ b/lib/rhdl/hdl/arithmetic/alu.rb
@@ -48,7 +48,7 @@ module RHDL
       input :a, width: :width
       input :b, width: :width
       input :op, width: 4
-      input :cin
+      input :cin, default: 0
       output :result, width: :width
       output :cout
       output :zero

--- a/lib/rhdl/hdl/sequential/program_counter.rb
+++ b/lib/rhdl/hdl/sequential/program_counter.rb
@@ -11,13 +11,15 @@ module RHDL
       include RHDL::DSL::Behavior
       include RHDL::DSL::Sequential
 
+      parameter :width, default: 16
+
       input :clk
       input :rst
-      input :en          # Increment enable
-      input :load        # Load new address
-      input :d, width: 16
-      input :inc, width: 16  # Increment amount (usually 1, 2, or 3)
-      output :q, width: 16
+      input :en, default: 0        # Increment enable
+      input :load, default: 0      # Load new address
+      input :d, width: :width
+      input :inc, width: :width, default: 1  # Increment amount (usually 1, 2, or 3)
+      output :q, width: :width
 
       # Sequential block for program counter
       # Priority: load > en (increment)

--- a/lib/rhdl/hdl/sequential/register.rb
+++ b/lib/rhdl/hdl/sequential/register.rb
@@ -11,11 +11,13 @@ module RHDL
       include RHDL::DSL::Behavior
       include RHDL::DSL::Sequential
 
-      input :d, width: 8
+      parameter :width, default: 8
+
+      input :d, width: :width
       input :clk
-      input :rst
-      input :en
-      output :q, width: 8
+      input :rst, default: 0
+      input :en, default: 0
+      output :q, width: :width
 
       # Sequential block for register
       sequential clock: :clk, reset: :rst, reset_values: { q: 0 } do

--- a/lib/rhdl/hdl/sequential/stack_pointer.rb
+++ b/lib/rhdl/hdl/sequential/stack_pointer.rb
@@ -11,11 +11,14 @@ module RHDL
       include RHDL::DSL::Behavior
       include RHDL::DSL::Sequential
 
+      parameter :width, default: 8
+      parameter :initial_rhdl, default: 255  # initial is reserved in Verilog
+
       input :clk
-      input :rst
-      input :push     # Decrement SP
-      input :pop      # Increment SP
-      output :q, width: 8
+      input :rst, default: 0
+      input :push, default: 0     # Decrement SP
+      input :pop, default: 0      # Increment SP
+      output :q, width: :width
       output :empty   # SP at max (empty stack)
       output :full    # SP at 0 (full stack)
 

--- a/lib/rhdl/simulation/sequential_component.rb
+++ b/lib/rhdl/simulation/sequential_component.rb
@@ -53,7 +53,29 @@ module RHDL
           name = top_name || verilog_module_name
 
           ports = _ports.map do |p|
-            RHDL::Export::IR::Port.new(name: p.name, direction: p.direction, width: p.width)
+            RHDL::Export::IR::Port.new(
+              name: p.name,
+              direction: p.direction,
+              width: p.width,
+              default: p.default
+            )
+          end
+
+          # Build parameters hash from class-level parameter definitions
+          # Convert Procs to their evaluated values using default values
+          parameters = {}
+          _parameter_defs.each do |param_name, default_val|
+            if default_val.is_a?(Proc)
+              # For class-level evaluation, use default parameter values
+              eval_context = Object.new
+              _parameter_defs.each do |k, v|
+                next if v.is_a?(Proc)
+                eval_context.instance_variable_set(:"@#{k}", v)
+              end
+              parameters[param_name] = eval_context.instance_exec(&default_val)
+            else
+              parameters[param_name] = default_val
+            end
           end
 
           # Get sequential IR if defined
@@ -76,25 +98,35 @@ module RHDL
 
           # Also check for behavior blocks (for combinational parts)
           behavior_result = behavior_to_ir_assigns
+          assigns = behavior_result[:assigns]
 
           # Generate instances from structure definitions
           instances = structure_to_ir_instances
 
           # Identify signals driven by instance outputs (these must be wires, not regs)
-          # A signal is instance-driven if it's the destination of a connection from [inst, port]
+          # Also generate assign statements for signal-to-signal connections
           instance_driven_signals = Set.new
+          signal_assigns = []
           _connection_defs.each do |conn|
             source, dest = conn[:source], conn[:dest]
             # If source is [inst_name, port_name], then dest is driven by an instance output
             if source.is_a?(Array) && source.length == 2 && dest.is_a?(Symbol)
               instance_driven_signals.add(dest)
+            # If both are symbols, generate an assign statement (signal-to-signal connection)
+            elsif source.is_a?(Symbol) && dest.is_a?(Symbol)
+              source_width = find_signal_width(source)
+              signal_assigns << RHDL::Export::IR::Assign.new(
+                target: dest.to_s,
+                expr: RHDL::Export::IR::Signal.new(name: source.to_s, width: source_width)
+              )
             end
           end
+          assigns = assigns + signal_assigns
 
           # Identify signals driven by continuous assigns (these must be wires, not regs)
           # In Verilog, 'reg' cannot be driven by 'assign' statements
           assign_driven_signals = Set.new
-          behavior_result[:assigns].each do |assign|
+          assigns.each do |assign|
             assign_driven_signals.add(assign.target.to_sym)
           end
 
@@ -112,7 +144,6 @@ module RHDL
           # Generate memory IR from MemoryDSL if included
           memories = []
           write_ports = []
-          assigns = behavior_result[:assigns]
           if respond_to?(:_memories) && !_memories.empty?
             memory_ir = memory_dsl_to_ir
             memories = memory_ir[:memories]
@@ -130,7 +161,8 @@ module RHDL
             instances: instances,
             reg_ports: reg_ports,
             memories: memories,
-            write_ports: write_ports
+            write_ports: write_ports,
+            parameters: parameters
           )
         end
 

--- a/spec/support/netlist_helper.rb
+++ b/spec/support/netlist_helper.rb
@@ -439,7 +439,7 @@ module NetlistHelper
     File.write(module_path, verilog_source)
     File.write(tb_path, generate_behavior_testbench(module_name, inputs, outputs, test_vectors, has_clock: has_clock))
 
-    compile = run_cmd(["iverilog", "-g2005", "-o", "sim.out", "tb.v", "#{module_name}.v"], cwd: base_dir)
+    compile = run_cmd(["iverilog", "-g2012", "-o", "sim.out", "tb.v", "#{module_name}.v"], cwd: base_dir)
     return { success: false, error: "Compilation failed: #{compile[:stderr]}\n#{compile[:stdout]}" } unless compile[:status].success?
 
     run = run_cmd(["vvp", "sim.out"], cwd: base_dir)


### PR DESCRIPTION
This new test file verifies that the HDL CPU's Verilog export correctly
executes full programs by comparing Verilog simulation results with
expected values.

Tests include:
- Simple arithmetic (3 + 5 = 8)
- Loop countdown with conditional branching
- Fibonacci sequence computation
- Multiplication via repeated addition (6 * 7 = 42)
- Factorial computation (5! = 120)
- Division (100 / 7 = 14)
- Bitwise operations (AND, OR, XOR, NOT)
- Conditional branching (JZ, JNZ)
- CALL and RET subroutines
- Compare instruction (CMP) with zero flag

Key implementation details:
- Generates Verilog testbench that mimics Ruby CPU harness behavior
- Adds parameter blocks to component modules for proper instantiation
- Fixes internal wire assignments in CPU module
- Uses SystemVerilog (-g2012) for variable declarations in tasks
- Adds proper #1 delays after clock edges for signal propagation

Requires iverilog to be installed; tests skip automatically if unavailable.