### PR TITLE
Remove all VHDL-related code and references

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ rhdl tui --list                          # List available components
 rhdl diagram --all                       # Generate all diagrams
 rhdl diagram RHDL::HDL::ALU --format svg # Single component diagram
 
-# Verilog/VHDL export
+# Verilog export
 rhdl export --all                        # Export all components
 rhdl export --lang verilog --out ./out RHDL::HDL::Counter
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,7 +23,7 @@ bundle exec rhdl --help
 |---------|-------------|
 | `tui` | Launch interactive TUI debugger |
 | `diagram` | Generate circuit diagrams |
-| `export` | Export components to Verilog or VHDL |
+| `export` | Export components to Verilog |
 | `gates` | Gate-level synthesis |
 | `apple2` | Apple II emulator and ROM tools |
 
@@ -190,7 +190,7 @@ rhdl diagram --clean
 
 ## Export Command
 
-Export HDL components to Verilog or VHDL.
+Export HDL components to Verilog.
 
 ### Usage
 
@@ -205,7 +205,7 @@ rhdl export [options] [ComponentRef]
 | `--all` | Export all components |
 | `--scope SCOPE` | Batch scope: `all`, `lib`, or `examples` |
 | `--clean` | Clean all generated HDL files |
-| `--lang LANG` | Target language: `verilog` or `vhdl` |
+| `--lang LANG` | Target language: `verilog` |
 | `--out DIR` | Output directory |
 | `--top NAME` | Override top module/entity name |
 | `-h, --help` | Show help |
@@ -460,5 +460,5 @@ Use `rhdl tui --list` to see all available components:
 
 - [Debugging Guide](debugging.md) - Detailed TUI and debugging documentation
 - [Diagrams Guide](diagrams.md) - Diagram generation details
-- [Export Guide](export.md) - Verilog/VHDL export details
+- [Export Guide](export.md) - Verilog export details
 - [Components Reference](components.md) - Complete component documentation

--- a/examples/mos6502/hdl/alu.rb
+++ b/examples/mos6502/hdl/alu.rb
@@ -1,6 +1,6 @@
 # MOS 6502 ALU - Fully Synthesizable DSL Version
 # Complete implementation with Binary Coded Decimal (BCD) mode
-# Uses behavior DSL for Verilog/VHDL export
+# Uses behavior DSL for Verilog export
 
 require_relative '../../../lib/rhdl'
 require_relative '../../../lib/rhdl/dsl/behavior'

--- a/examples/mos6502/hdl/memory.rb
+++ b/examples/mos6502/hdl/memory.rb
@@ -1,5 +1,5 @@
 # MOS 6502 Memory Interface - Synthesizable DSL Version
-# Uses MemoryDSL for Verilog/VHDL export
+# Uses MemoryDSL for Verilog export
 # 64KB addressable memory with RAM and ROM regions
 
 require_relative '../../../lib/rhdl'

--- a/examples/mos6502/hdl/registers.rb
+++ b/examples/mos6502/hdl/registers.rb
@@ -1,6 +1,6 @@
 # MOS 6502 CPU Registers - Synthesizable DSL Version
 # Contains A, X, Y registers, Stack Pointer, Program Counter, and latches
-# All components use synthesizable patterns for Verilog/VHDL export
+# All components use synthesizable patterns for Verilog export
 
 require_relative '../../../lib/rhdl'
 

--- a/exe/rhdl
+++ b/exe/rhdl
@@ -16,7 +16,7 @@ def show_help
     Commands:
       tui           Launch interactive TUI debugger
       diagram       Generate circuit diagrams
-      export        Export components to Verilog or VHDL
+      export        Export components to Verilog
       gates         Gate-level synthesis
       apple2        Apple II emulator and ROM tools
       generate      Generate all output files (diagrams + HDL exports)
@@ -164,7 +164,7 @@ def handle_export(args)
     opts.banner = <<~BANNER
       Usage: rhdl export [options] [ComponentRef]
 
-      Export HDL components to Verilog or VHDL.
+      Export HDL components to Verilog.
 
       Single component mode:
         rhdl export --lang verilog --out ./output RHDL::HDL::Counter
@@ -180,7 +180,7 @@ def handle_export(args)
     opts.on('--all', 'Export all components') { options[:all] = true }
     opts.on('--scope SCOPE', 'Batch scope: all, lib, or examples') { |v| options[:scope] = v }
     opts.on('--clean', 'Clean all generated HDL files') { options[:clean] = true }
-    opts.on('--lang LANG', 'Target language: verilog or vhdl') { |v| options[:lang] = v }
+    opts.on('--lang LANG', 'Target language: verilog') { |v| options[:lang] = v }
     opts.on('--out DIR', 'Output directory') { |v| options[:out] = v }
     opts.on('--top NAME', 'Override top module/entity name') { |v| options[:top] = v }
     opts.on('-h', '--help', 'Show this help') do

--- a/lib/rhdl/cli/tasks/export_task.rb
+++ b/lib/rhdl/cli/tasks/export_task.rb
@@ -6,7 +6,7 @@ require_relative '../config'
 module RHDL
   module CLI
     module Tasks
-      # Task for exporting HDL components to Verilog/VHDL
+      # Task for exporting HDL components to Verilog
       class ExportTask < Task
         def run
           if options[:clean]
@@ -84,18 +84,13 @@ module RHDL
           component_class = component_ref.split("::").inject(Object) { |mod, name| mod.const_get(name) }
           ensure_dir(out_dir)
 
-          case lang
-          when "verilog"
-            top_name = options[:top] || component_class.name.split("::").last.underscore
-            output_path = File.join(out_dir, "#{top_name}.v")
-            RHDL::Export.write_verilog(component_class, path: output_path, top_name: options[:top])
-          when "vhdl"
-            top_name = options[:top] || component_class.name.split("::").last.underscore
-            output_path = File.join(out_dir, "#{top_name}.vhd")
-            RHDL::Export.write_vhdl(component_class, path: output_path, top_name: options[:top])
-          else
-            raise ArgumentError, "Unknown language: #{lang}"
+          unless lang == "verilog"
+            raise ArgumentError, "Unknown language: #{lang}. Only 'verilog' is supported."
           end
+
+          top_name = options[:top] || component_class.name.split("::").last.underscore
+          output_path = File.join(out_dir, "#{top_name}.v")
+          RHDL::Export.write_verilog(component_class, path: output_path, top_name: options[:top])
 
           puts "Wrote #{lang} to #{out_dir}"
         end

--- a/lib/rhdl/sim/component.rb
+++ b/lib/rhdl/sim/component.rb
@@ -454,11 +454,6 @@ module RHDL
         end
         alias_method :to_firrtl_hierarchy, :to_circt_hierarchy
 
-        # Generate VHDL from the component
-        def to_vhdl(top_name: nil)
-          RHDL::Export::VHDL.generate(to_ir(top_name: top_name))
-        end
-
         # Returns the Verilog module name for this component
         # Derived from the class's full module path, filtering out RHDL/HDL namespaces
         # Examples:
@@ -505,22 +500,6 @@ module RHDL
 
           # Generate top-level module last
           parts << to_verilog(top_name: top_name)
-
-          parts.join("\n\n")
-        end
-
-        # Generate VHDL for this component and all its sub-modules
-        # @param top_name [String] Optional name override for top module
-        # @return [String] Complete VHDL with all module definitions
-        def to_vhdl_hierarchy(top_name: nil)
-          parts = []
-
-          submodules = collect_submodule_classes
-          submodules.each do |submod|
-            parts << submod.to_vhdl
-          end
-
-          parts << to_vhdl(top_name: top_name)
 
           parts.join("\n\n")
         end


### PR DESCRIPTION
VHDL export was never fully implemented. This removes:
- to_vhdl and to_vhdl_hierarchy methods from component.rb
- VHDL case handling from export_task.rb
- VHDL references from CLI help and documentation
- VHDL mentions from example file comments