### PR TITLE
Claude/fix hires viewport resize w a nw2

### DIFF
--- a/examples/mos6502/bin/apple2
+++ b/examples/mos6502/bin/apple2
@@ -76,6 +76,10 @@ class Apple2Terminal
     @fps = 0.0
     @last_fps_time = nil
     @fps_frame_count = 0
+
+    # Input tracking for debug
+    @last_key = nil
+    @last_key_time = nil
   end
 
   def update_terminal_size
@@ -244,6 +248,10 @@ class Apple2Terminal
     # Convert lowercase to uppercase for Apple II
     ascii = ascii - 32 if ascii >= 97 && ascii <= 122
 
+    # Track for debug display
+    @last_key = ascii
+    @last_key_time = Time.now
+
     # Inject the key
     @runner.inject_key(ascii)
   rescue IO::WaitReadable, Errno::EAGAIN
@@ -311,10 +319,11 @@ class Apple2Terminal
       output << move_cursor(status_row, @hires_pad_left + 1)
       output << status
       status_row += 1
-      # Line 2: Cycles, uptime, disk info
-      status2 = format("Cyc:%s Up:%s | Disk:T%02d %s",
+      # Line 2: Cycles, uptime, key, disk info
+      status2 = format("Cyc:%s Up:%s Key:%-3s | Disk:T%02d %s",
                        format_cycles(state[:cycles]),
                        format_uptime(@start_time),
+                       format_key(@last_key),
                        dc.track, dc.motor_on ? "ON " : "OFF")
       output << move_cursor(status_row, @hires_pad_left + 1)
       output << status2
@@ -378,12 +387,13 @@ class Apple2Terminal
       output << status
       status_row += 1
 
-      # Line 2: Cycles, uptime, disk and video info
+      # Line 2: Cycles, uptime, key, disk and video info
       dc = @runner.bus.disk_controller
       mode = @runner.bus.display_mode
-      status2 = format("Cyc:%s Up:%s | Disk:T%02d %s | %s",
+      status2 = format("Cyc:%s Up:%s Key:%-3s | Disk:T%02d %s | %s",
                        format_cycles(state[:cycles]),
                        format_uptime(@start_time),
+                       format_key(@last_key),
                        dc.track, dc.motor_on ? "ON " : "OFF",
                        mode.to_s.upcase)
       output << move_cursor(status_row, @pad_left + 1)
@@ -456,6 +466,25 @@ class Apple2Terminal
       format("%d:%02d:%02d", hours, minutes, seconds)
     else
       format("%d:%02d", minutes, seconds)
+    end
+  end
+
+  def format_key(ascii)
+    return "---" unless ascii
+    # Clear key display after 2 seconds
+    return "---" if @last_key_time && (Time.now - @last_key_time) > 2.0
+
+    case ascii
+    when 0x00..0x1F
+      # Control characters
+      ctrl_char = (ascii + 0x40).chr
+      "^#{ctrl_char}"
+    when 0x20
+      "SPC"
+    when 0x7F
+      "DEL"
+    else
+      "'#{ascii.chr}'"
     end
   end
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves Apple ][ terminal rendering and observability.
> 
> - Centers hi-res graphics with calculated top/left padding; positions status lines accordingly and centers disk-loading message
> - Adds performance monitoring (Hz/FPS/uptime) and key tracking; surfaces in expanded two-line debug HUD for both text and hi-res modes
> - Refactors frame counters and periodic metric updates; adjusts display refresh cadence and display height calculations in debug vs non-debug
> - Removes unnecessary full-screen clears in hi-res rendering; maintains green-screen mode handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff0f6cf678ea2e3f58e691852f375e26c76f6135. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->