### PR TITLE
Add simulator_type to debug info

### DIFF
--- a/examples/mos6502/utilities/apple2_harness.rb
+++ b/examples/mos6502/utilities/apple2_harness.rb
@@ -97,7 +97,8 @@ module Apple2Harness
         sp: dp.read_sp,
         p: dp.read_p,
         cycles: @cpu.clock_count,
-        halted: @cpu.halted?
+        halted: @cpu.halted?,
+        simulator_type: simulator_type
       }
     end
 
@@ -109,6 +110,12 @@ module Apple2Harness
     # Get total CPU cycles
     def cycle_count
       @cpu.clock_count
+    end
+
+    # Get the simulator type
+    # @return [Symbol] :hdl for cycle-accurate HDL simulation
+    def simulator_type
+      :hdl
     end
   end
 
@@ -244,7 +251,8 @@ module Apple2Harness
         sp: @cpu.sp,
         p: @cpu.p,
         cycles: @cpu.cycles,
-        halted: @cpu.halted?
+        halted: @cpu.halted?,
+        simulator_type: simulator_type
       }
     end
 
@@ -254,6 +262,12 @@ module Apple2Harness
 
     def cycle_count
       @cpu.cycles
+    end
+
+    # Get the simulator type
+    # @return [Symbol] :native for Rust implementation, :ruby for pure Ruby
+    def simulator_type
+      native? ? :native : :ruby
     end
   end
 end

--- a/examples/mos6502/utilities/isa_simulator_native.rb
+++ b/examples/mos6502/utilities/isa_simulator_native.rb
@@ -73,6 +73,12 @@ module MOS6502
           self.p = self.p & ~(1 << flag)
         end
       end
+
+      # Check if this is the native implementation
+      # @return [Boolean] true for native Rust implementation
+      def native?
+        true
+      end
     end
   else
     # Fallback: alias the pure Ruby implementation


### PR DESCRIPTION
- Add native? method to ISASimulatorNative class (returns true)
- Add simulator_type method to Runner (:hdl) and ISARunner (:native/:ruby)
- Include simulator_type in cpu_state hash for debugging

The debug info now shows which simulator backend is running:
- :hdl - Cycle-accurate HDL simulation
- :native - Fast Rust ISA-level simulation
- :ruby - Pure Ruby ISA-level simulation (fallback)