### PR TITLE
Add audio support for Apple II emulator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -565,6 +565,7 @@ Follow these conventions for file organization:
 - Each spec file should test exactly one class or module
 - Spec files should mirror the lib directory structure (e.g., `spec/rhdl/simulation/simulator_spec.rb` for `lib/rhdl/simulation/simulator.rb`)
 - Name spec files with `_spec.rb` suffix matching the class being tested
+- **IMPORTANT: Always add a test file when creating a new source file.** Every new class or module should have a corresponding spec file.
 
 **HDL directory organization:**
 - The `lib/rhdl/hdl/` directory should only contain component definitions

--- a/examples/mos6502/bin/apple2
+++ b/examples/mos6502/bin/apple2
@@ -166,6 +166,7 @@ class Apple2Terminal
     @green_screen = options[:green] || false
     @hires_mode = options[:hires] || false
     @hires_width = options[:hires_width] || 80
+    @audio_enabled = options[:audio] != false
 
     # Terminal size and padding for centering
     @term_rows = 24
@@ -278,10 +279,16 @@ class Apple2Terminal
 
     mode_names = { native: "Native ISA", ruby: "Ruby ISA", hdl: "HDL (cycle-accurate)" }
     mode = mode_names[@sim_type] || @sim_type.to_s
-    puts "Starting Apple ][ emulator... [#{mode} mode]"
+    audio_status = @audio_enabled ? "Audio ON" : "Audio OFF"
+    puts "Starting Apple ][ emulator... [#{mode} mode, #{audio_status}]"
     puts "Press Ctrl+C to exit"
     puts "Press any key to continue..."
     sleep 0.5
+
+    # Start audio if enabled
+    if @audio_enabled
+      @runner.bus.start_audio
+    end
 
     # Reset the CPU
     @runner.reset
@@ -327,8 +334,16 @@ class Apple2Terminal
       # Check for keyboard input (non-blocking)
       handle_keyboard_input
 
+      # Get cycle count before running
+      cycles_before = @runner.cycle_count
+
       # Run CPU cycles
       @runner.run_steps(@cycles_per_frame)
+
+      # Get cycles actually executed and update bus timing
+      cycles_after = @runner.cycle_count
+      cycles_executed = cycles_after - cycles_before
+      @runner.bus.tick(cycles_executed) if cycles_executed > 0
 
       # Update performance metrics
       update_performance_metrics
@@ -678,6 +693,9 @@ class Apple2Terminal
   end
 
   def cleanup
+    # Stop audio
+    @runner.bus.stop_audio if @audio_enabled
+
     print SHOW_CURSOR
     print NORMAL_VIDEO
     # Position exit message below the display area
@@ -816,7 +834,8 @@ options = {
   demo: false,
   mode: :native,  # Simulator mode: native, ruby, or hdl
   hires: false,
-  hires_width: 80
+  hires_width: 80,
+  audio: true  # Audio enabled by default
 }
 
 parser = OptionParser.new do |opts|
@@ -888,6 +907,10 @@ parser = OptionParser.new do |opts|
 
   opts.on("-k", "--karateka", "Load Karateka memory dump (ready to play)") do
     options[:karateka] = true
+  end
+
+  opts.on("--no-audio", "Disable audio output") do
+    options[:audio] = false
   end
 
   opts.on("-h", "--help", "Show this help message") do

--- a/examples/mos6502/utilities/apple2_speaker.rb
+++ b/examples/mos6502/utilities/apple2_speaker.rb
@@ -1,0 +1,254 @@
+# Apple II Speaker Emulation
+# Generates audio from speaker toggle events at $C030
+
+module MOS6502
+  class Apple2Speaker
+    # Audio sample rate (standard)
+    SAMPLE_RATE = 22050
+
+    # Buffer size in samples (smaller = lower latency, larger = more stable)
+    BUFFER_SIZE = 512
+
+    # Maximum amplitude for 16-bit signed audio
+    AMPLITUDE = 12000
+
+    # Minimum time between toggles to count as audio (filter noise)
+    MIN_TOGGLE_INTERVAL = 0.00001  # 10 microseconds (100kHz max)
+
+    # Maximum time between toggles before we consider it silence
+    MAX_TOGGLE_INTERVAL = 0.1  # 100ms
+
+    attr_reader :enabled
+
+    def initialize
+      @enabled = false  # Start disabled, enable explicitly
+      @speaker_state = false  # false = low, true = high
+      @last_toggle_time = nil
+      @sample_buffer = []
+      @sample_position = 0.0
+      @audio_thread = nil
+      @mutex = Mutex.new
+      @running = false
+      @audio_pipe = nil
+      @audio_cmd = nil
+    end
+
+    # Toggle the speaker (called when $C030 is accessed)
+    def toggle(_cycle = 0)
+      return unless @enabled && @running
+
+      now = Time.now
+      if @last_toggle_time
+        interval = now - @last_toggle_time
+
+        # Only generate audio for reasonable toggle frequencies
+        if interval > MIN_TOGGLE_INTERVAL && interval < MAX_TOGGLE_INTERVAL
+          generate_samples(interval)
+        end
+      end
+
+      @last_toggle_time = now
+      @speaker_state = !@speaker_state
+    end
+
+    # Update cycle (compatibility method - uses time internally)
+    def update_cycle(_cycle)
+      # No-op - we use wall-clock time
+    end
+
+    # Generate audio samples for a time interval
+    def generate_samples(interval)
+      num_samples = (interval * SAMPLE_RATE).to_i
+      return if num_samples <= 0 || num_samples > SAMPLE_RATE  # Sanity check
+
+      sample_value = @speaker_state ? AMPLITUDE : -AMPLITUDE
+
+      @mutex.synchronize do
+        num_samples.times do
+          @sample_buffer << sample_value
+        end
+
+        # Write to audio pipe if we have enough samples
+        flush_to_pipe if @sample_buffer.size >= BUFFER_SIZE
+      end
+    end
+
+    # Start audio playback
+    def start
+      return if @running
+
+      @audio_cmd = find_audio_command
+      unless @audio_cmd
+        warn "No audio player found (tried paplay, aplay, play)"
+        return
+      end
+
+      @running = true
+      @enabled = true
+      @last_toggle_time = nil
+      start_audio_pipe
+    end
+
+    # Stop audio playback
+    def stop
+      return unless @running
+
+      @running = false
+      @enabled = false
+      stop_audio_pipe
+    end
+
+    # Enable/disable audio
+    def enable(state)
+      @enabled = state
+    end
+
+    # Check if audio system is available
+    def self.available?
+      system('which paplay > /dev/null 2>&1') ||
+        system('which aplay > /dev/null 2>&1') ||
+        system('which play > /dev/null 2>&1')
+    end
+
+    private
+
+    def find_audio_command
+      # Prefer paplay (PulseAudio) - works well on most Linux systems
+      if system('which paplay > /dev/null 2>&1')
+        return ['paplay', '--raw', "--rate=#{SAMPLE_RATE}", '--channels=1', '--format=s16le']
+      end
+
+      # Try aplay (ALSA) - direct hardware access
+      if system('which aplay > /dev/null 2>&1')
+        return ['aplay', '-q', '-f', 'S16_LE', '-r', SAMPLE_RATE.to_s, '-c', '1']
+      end
+
+      # Try sox play
+      if system('which play > /dev/null 2>&1')
+        return ['play', '-q', '-t', 'raw', '-r', SAMPLE_RATE.to_s, '-e', 'signed', '-b', '16', '-c', '1', '-']
+      end
+
+      nil
+    end
+
+    def start_audio_pipe
+      return unless @audio_cmd
+
+      begin
+        @audio_pipe = IO.popen(@audio_cmd, 'wb')
+        @audio_thread = Thread.new { audio_writer_thread }
+      rescue => e
+        warn "Failed to start audio: #{e.message}"
+        @audio_pipe = nil
+      end
+    end
+
+    def stop_audio_pipe
+      @audio_thread&.kill
+      @audio_thread = nil
+
+      if @audio_pipe
+        begin
+          @audio_pipe.close
+        rescue
+          nil
+        end
+        @audio_pipe = nil
+      end
+    end
+
+    def audio_writer_thread
+      while @running
+        samples = nil
+
+        @mutex.synchronize do
+          if @sample_buffer.size >= BUFFER_SIZE
+            samples = @sample_buffer.shift(BUFFER_SIZE)
+          end
+        end
+
+        if samples
+          write_samples(samples)
+        else
+          # No samples - generate a tiny bit of silence to keep pipe alive
+          sleep 0.01
+        end
+      end
+    end
+
+    def flush_to_pipe
+      # Called within mutex - extract samples and write
+      return unless @audio_pipe && @sample_buffer.size >= BUFFER_SIZE
+
+      samples = @sample_buffer.shift(BUFFER_SIZE)
+      write_samples_unlocked(samples)
+    end
+
+    def write_samples(samples)
+      return unless @audio_pipe && !samples.empty?
+
+      begin
+        raw_data = samples.pack('s<*')
+        @audio_pipe.write(raw_data)
+        @audio_pipe.flush
+      rescue Errno::EPIPE, IOError => e
+        warn "Audio pipe error: #{e.message}" if ENV['DEBUG']
+        # Restart the pipe
+        stop_audio_pipe
+        start_audio_pipe
+      end
+    end
+
+    def write_samples_unlocked(samples)
+      return unless @audio_pipe && !samples.empty?
+
+      begin
+        raw_data = samples.pack('s<*')
+        @audio_pipe.write(raw_data)
+      rescue Errno::EPIPE, IOError
+        # Will be handled by audio thread
+      end
+    end
+  end
+
+  # Simple beep-based audio fallback for systems without audio utilities
+  class Apple2SpeakerBeep
+    attr_reader :enabled
+
+    def initialize
+      @enabled = true
+      @toggle_count = 0
+      @last_beep_time = Time.now
+    end
+
+    def toggle(_cycle = 0)
+      @toggle_count += 1
+
+      # Beep occasionally to indicate audio activity
+      if @toggle_count % 5000 == 0 && (Time.now - @last_beep_time) > 0.5
+        print "\a" if @enabled  # Terminal bell
+        @last_beep_time = Time.now
+      end
+    end
+
+    def update_cycle(_cycle)
+      # No-op
+    end
+
+    def start
+      # No-op
+    end
+
+    def stop
+      # No-op
+    end
+
+    def enable(state)
+      @enabled = state
+    end
+
+    def self.available?
+      true
+    end
+  end
+end

--- a/spec/examples/mos6502/apple2_speaker_spec.rb
+++ b/spec/examples/mos6502/apple2_speaker_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+require_relative '../../../examples/mos6502/utilities/apple2_speaker'
+
+RSpec.describe MOS6502::Apple2Speaker do
+  subject(:speaker) { described_class.new }
+
+  describe '#initialize' do
+    it 'starts disabled' do
+      expect(speaker.enabled).to be false
+    end
+  end
+
+  describe '#toggle' do
+    it 'accepts a cycle parameter' do
+      expect { speaker.toggle(1000) }.not_to raise_error
+    end
+
+    it 'does nothing when disabled' do
+      # Should not raise error or produce audio when disabled
+      10.times { speaker.toggle(1000) }
+    end
+  end
+
+  describe '#update_cycle' do
+    it 'accepts a cycle parameter' do
+      expect { speaker.update_cycle(1000) }.not_to raise_error
+    end
+  end
+
+  describe '#start' do
+    it 'enables the speaker' do
+      # Note: actual audio playback requires audio system
+      speaker.start
+      # If audio system not available, enabled will still be set
+      # but no error should be raised
+    end
+  end
+
+  describe '#stop' do
+    it 'disables the speaker' do
+      speaker.start
+      speaker.stop
+      expect(speaker.enabled).to be false
+    end
+  end
+
+  describe '#enable' do
+    it 'sets enabled state' do
+      speaker.enable(true)
+      expect(speaker.enabled).to be true
+
+      speaker.enable(false)
+      expect(speaker.enabled).to be false
+    end
+  end
+
+  describe '.available?' do
+    it 'returns a boolean' do
+      result = described_class.available?
+      expect(result).to be(true).or be(false)
+    end
+  end
+end
+
+RSpec.describe MOS6502::Apple2SpeakerBeep do
+  subject(:speaker) { described_class.new }
+
+  describe '#initialize' do
+    it 'starts enabled' do
+      expect(speaker.enabled).to be true
+    end
+  end
+
+  describe '#toggle' do
+    it 'accepts a cycle parameter' do
+      expect { speaker.toggle(1000) }.not_to raise_error
+    end
+
+    it 'increments toggle count' do
+      100.times { speaker.toggle(0) }
+      # Should not raise error
+    end
+  end
+
+  describe '#enable' do
+    it 'sets enabled state' do
+      speaker.enable(false)
+      expect(speaker.enabled).to be false
+
+      speaker.enable(true)
+      expect(speaker.enabled).to be true
+    end
+  end
+
+  describe '.available?' do
+    it 'always returns true' do
+      expect(described_class.available?).to be true
+    end
+  end
+end


### PR DESCRIPTION
- Create Apple2Speaker class for real-time audio generation from speaker toggles at $C030
- Use wall-clock time for toggle timing (works with both native and Ruby simulators)
- Support paplay (PulseAudio), aplay (ALSA), and sox play audio backends
- Integrate speaker into Apple2Bus with start_audio/stop_audio methods
- Add --no-audio flag to disable audio in terminal emulator
- Update main loop to track cycles and update bus timing
- Add Apple2SpeakerBeep fallback class for systems without audio utilities
- Add test suite for speaker classes
- Update CLAUDE.md with requirement to add tests for new files