### PR TITLE
Add macOS audio support and audio status in debug panel

### DIFF
--- a/examples/mos6502/bin/apple2
+++ b/examples/mos6502/bin/apple2
@@ -479,10 +479,12 @@ class Apple2Terminal
                      format_hz(@current_hz), @fps,
                      format_uptime(@start_time))
 
-      # Line 3: Disk IO / keyboard IO
-      line3 = format("Disk:T%02d %s | Key:%-3s",
+      # Line 3: Disk IO / keyboard IO / Audio
+      speaker = @runner.bus.speaker
+      audio_status = speaker.status
+      line3 = format("Disk:T%02d %s | Key:%-3s | Audio:%s",
                      dc.track, dc.motor_on ? "ON " : "OFF",
-                     format_key(@last_key))
+                     format_key(@last_key), audio_status)
 
       # Pad/truncate lines to fit within border
       line1 = line1.ljust(debug_width)[0, debug_width]
@@ -570,11 +572,13 @@ class Apple2Terminal
                      format_hz(@current_hz), @fps,
                      format_uptime(@start_time))
 
-      # Line 3: Disk IO / keyboard IO / video mode
-      line3 = format("Disk:T%02d %s | Key:%-3s | %s",
+      # Line 3: Disk IO / keyboard IO / video mode / Audio
+      speaker = @runner.bus.speaker
+      audio_status = speaker.status
+      line3 = format("Disk:T%02d %s|Key:%-3s|%s|Audio:%s",
                      dc.track, dc.motor_on ? "ON " : "OFF",
                      format_key(@last_key),
-                     mode.to_s.upcase)
+                     mode.to_s.upcase, audio_status)
 
       # Pad/truncate lines to fit within border
       line1 = line1.ljust(SCREEN_COLS)[0, SCREEN_COLS]

--- a/spec/examples/mos6502/apple2_speaker_spec.rb
+++ b/spec/examples/mos6502/apple2_speaker_spec.rb
@@ -10,6 +10,21 @@ RSpec.describe MOS6502::Apple2Speaker do
     it 'starts disabled' do
       expect(speaker.enabled).to be false
     end
+
+    it 'starts with zero toggle count' do
+      expect(speaker.toggle_count).to eq 0
+    end
+  end
+
+  describe '#status' do
+    it 'returns off when not started' do
+      expect(speaker.status).to eq 'off'
+    end
+
+    it 'returns backend name or none after start' do
+      speaker.start
+      expect(['sox', 'ffplay', 'paplay', 'aplay', 'none', 'no backend', 'off']).to include(speaker.status)
+    end
   end
 
   describe '#toggle' do
@@ -71,6 +86,10 @@ RSpec.describe MOS6502::Apple2SpeakerBeep do
     it 'starts enabled' do
       expect(speaker.enabled).to be true
     end
+
+    it 'starts with zero toggle count' do
+      expect(speaker.toggle_count).to eq 0
+    end
   end
 
   describe '#toggle' do
@@ -80,7 +99,18 @@ RSpec.describe MOS6502::Apple2SpeakerBeep do
 
     it 'increments toggle count' do
       100.times { speaker.toggle(0) }
-      # Should not raise error
+      expect(speaker.toggle_count).to eq 100
+    end
+  end
+
+  describe '#status' do
+    it 'returns beep when enabled' do
+      expect(speaker.status).to eq 'beep'
+    end
+
+    it 'returns off when disabled' do
+      speaker.enable(false)
+      expect(speaker.status).to eq 'off'
     end
   end
 


### PR DESCRIPTION
- Add sox play as primary audio backend (works on macOS via brew install sox)
- Add ffplay (ffmpeg) as secondary option for macOS
- Add audio status to debug panel in both hires and text modes
- Track toggle count for debugging
- Add status() method to speaker classes for debug display
- Update tests for new status and toggle_count features