### PR TITLE
Fix hires mode display for --karateka in Ruby simulator mode

### DIFF
--- a/examples/mos6502/bin/apple2
+++ b/examples/mos6502/bin/apple2
@@ -888,6 +888,7 @@ parser = OptionParser.new do |opts|
 
   opts.on("-k", "--karateka", "Load Karateka memory dump (ready to play)") do
     options[:karateka] = true
+    options[:hires] = true  # Karateka uses hi-res graphics mode
   end
 
   opts.on("-h", "--help", "Show this help message") do


### PR DESCRIPTION
Set options[:hires] = true when using --karateka flag so that @hires_mode is enabled in the terminal. This ensures the fallback condition in render_screen triggers hires rendering even if soft switch state differs between Ruby and native simulation modes.