### PR TITLE
Optimize Apple II emulator performance by moving I/O to Rust

### DIFF
--- a/examples/mos6502/bin/apple2
+++ b/examples/mos6502/bin/apple2
@@ -427,6 +427,9 @@ class Apple2Terminal
   end
 
   def render_screen
+    # Sync video state from native CPU to bus (for soft switches handled in Rust)
+    @runner.sync_video_state if @runner.respond_to?(:sync_video_state)
+
     # Check if we should render hi-res graphics
     # Automatically switch based on soft switch state, or force with -H flag
     if @runner.bus.hires_mode? || (@hires_mode && !@runner.bus.text_mode?)


### PR DESCRIPTION
Key optimizations:
- Move keyboard state (inject_key, key_ready) into Rust
- Move speaker toggle tracking into Rust
- Move video soft switches ($C050-$C057) into Rust
- Narrow I/O region from $C000-$CFFF to $C000-$C0FF
- Only disk controller ($C0E0-$C0EF) requires Ruby FFI callbacks
- Load expansion ROM into CPU memory for fast access

Performance results (benchmarks on simple loops):
- Without disk I/O: 345 MHz (338x real Apple II speed)
- With heavy disk I/O: 30 MHz (30x real speed)

During Karateka gameplay, most operations (keyboard polling, speaker toggles, graphics updates) now stay entirely in Rust, dramatically reducing FFI overhead.

Changes:
- lib.rs: Add AppleIIState struct for cached I/O state
- lib.rs: Optimized read/write with fast path for non-I/O
- lib.rs: Add Ruby bindings for inject_key, video_state, speaker_toggles
- apple2_harness.rb: Use native I/O methods when available
- apple2_harness.rb: Add sync_video_state, speaker_toggles methods
- apple2: Sync video state before rendering