### PR TITLE
Fix native CPU audio playback by syncing speaker toggles to Ruby

### DIFF
--- a/examples/mos6502/bin/apple2
+++ b/examples/mos6502/bin/apple2
@@ -431,6 +431,9 @@ class Apple2Terminal
     # Sync video state from native CPU to bus (for soft switches handled in Rust)
     @runner.sync_video_state if @runner.respond_to?(:sync_video_state)
 
+    # Sync speaker toggles from native CPU to Ruby speaker (for audio generation)
+    @runner.sync_speaker_state if @runner.respond_to?(:sync_speaker_state)
+
     # Check if we should render hi-res graphics
     # Automatically switch based on soft switch state, or force with -H flag
     if @runner.bus.hires_mode? || (@hires_mode && !@runner.bus.text_mode?)


### PR DESCRIPTION
When using the native Rust CPU, speaker toggle events at $C030 were only incrementing an internal counter but not forwarding to the Ruby speaker for audio generation. This adds:

- sync_speaker_state() in ISARunner to forward toggles from native CPU
- sync_toggles() in Apple2Speaker to generate samples with timing estimation
- Call to sync_speaker_state in the render loop alongside sync_video_state

The fix estimates audio timing based on elapsed real-time and toggle count, allowing proper sample generation even when toggles are batched per-frame.