### PR TITLE
Fix Karateka not running after performance optimizations

### DIFF
--- a/examples/mos6502/bin/apple2
+++ b/examples/mos6502/bin/apple2
@@ -1049,7 +1049,12 @@ end
 # Initialize HIRES mode soft switches if requested
 # This is useful for loading memory dumps that were captured in HIRES mode
 if options[:init_hires]
-  bus = terminal.runner.bus
+  runner = terminal.runner
+  # For native mode, also set video state on the CPU (soft switches are handled in Rust)
+  if runner.native?
+    runner.cpu.set_video_state(false, false, false, true)  # text=false, mixed=false, page2=false, hires=true
+  end
+  bus = runner.bus
   bus.read(0xC050)  # TXTCLR - graphics mode
   bus.read(0xC052)  # MIXCLR - full screen
   bus.read(0xC054)  # PAGE1 - page 1


### PR DESCRIPTION
The performance optimization (commit 0570d47) moved video soft switch handling to Rust, but init_hires was only setting video state on the Ruby bus, not the Rust CPU's io_state. When sync_video_state was called, it would overwrite the correct bus state with the CPU's default values (text=true, hires=false), causing Karateka to display in text mode.

Fix: When init_hires is used with native mode, also call set_video_state on the CPU to initialize its io_state before running.