### PR TITLE
Fix hires mode initialization for native CPU

### DIFF
--- a/examples/mos6502/bin/apple2
+++ b/examples/mos6502/bin/apple2
@@ -1057,6 +1057,8 @@ if options[:init_hires]
   bus.read(0xC052)  # MIXCLR - full screen
   bus.read(0xC054)  # PAGE1 - page 1
   bus.read(0xC057)  # HIRES - hi-res mode
+  # Push video state to native CPU so it matches Ruby bus
+  terminal.runner.sync_video_to_native if terminal.runner.respond_to?(:sync_video_to_native)
 end
 
 # Run the emulator

--- a/examples/mos6502/utilities/apple2_harness.rb
+++ b/examples/mos6502/utilities/apple2_harness.rb
@@ -262,6 +262,18 @@ module Apple2Harness
       @bus.video[:hires] = video[:hires]
     end
 
+    # Sync video state from Ruby bus to native CPU (for initialization)
+    # Call this after setting soft switches on the bus to push state to native CPU
+    def sync_video_to_native
+      return unless native?
+      @cpu.set_video_state(
+        @bus.video[:text],
+        @bus.video[:mixed],
+        @bus.video[:page2],
+        @bus.video[:hires]
+      )
+    end
+
     # Sync speaker toggles from native CPU to Ruby speaker (for audio generation)
     # Called each frame to forward any new speaker toggles to the audio system
     def sync_speaker_state


### PR DESCRIPTION
When using init_hires, the soft switches were only being set on the Ruby bus but not synced to the native CPU's internal video state. This caused sync_video_state to overwrite the hires settings with the native CPU's default text mode on the first render frame.

Added sync_video_to_native() to push video state from Ruby bus to native CPU, called after init_hires initialization.