### PR TITLE
Add macOS linker config for Rust native extensions

### DIFF
--- a/examples/mos6502/utilities/isa_simulator_native/.cargo/config.toml
+++ b/examples/mos6502/utilities/isa_simulator_native/.cargo/config.toml
@@ -1,0 +1,8 @@
+# macOS linker flags for Ruby native extensions
+# Allows undefined symbols that get resolved at runtime when loaded by Ruby
+
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]

--- a/lib/rhdl/codegen/circt/sim/rtl_compiler/.cargo/config.toml
+++ b/lib/rhdl/codegen/circt/sim/rtl_compiler/.cargo/config.toml
@@ -1,0 +1,8 @@
+# macOS linker flags for Ruby native extensions
+# Allows undefined symbols that get resolved at runtime when loaded by Ruby
+
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]

--- a/lib/rhdl/codegen/circt/sim/rtl_interpreter/.cargo/config.toml
+++ b/lib/rhdl/codegen/circt/sim/rtl_interpreter/.cargo/config.toml
@@ -1,0 +1,8 @@
+# macOS linker flags for Ruby native extensions
+# Allows undefined symbols that get resolved at runtime when loaded by Ruby
+
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]

--- a/lib/rhdl/codegen/circt/sim/rtl_jit/.cargo/config.toml
+++ b/lib/rhdl/codegen/circt/sim/rtl_jit/.cargo/config.toml
@@ -1,0 +1,8 @@
+# macOS linker flags for Ruby native extensions
+# Allows undefined symbols that get resolved at runtime when loaded by Ruby
+
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]

--- a/lib/rhdl/codegen/netlist/sim/netlist_compiler/.cargo/config.toml
+++ b/lib/rhdl/codegen/netlist/sim/netlist_compiler/.cargo/config.toml
@@ -1,0 +1,8 @@
+# macOS linker flags for Ruby native extensions
+# Allows undefined symbols that get resolved at runtime when loaded by Ruby
+
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]

--- a/lib/rhdl/codegen/netlist/sim/netlist_interpreter/.cargo/config.toml
+++ b/lib/rhdl/codegen/netlist/sim/netlist_interpreter/.cargo/config.toml
@@ -1,0 +1,8 @@
+# macOS linker flags for Ruby native extensions
+# Allows undefined symbols that get resolved at runtime when loaded by Ruby
+
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]

--- a/lib/rhdl/codegen/netlist/sim/netlist_jit/.cargo/config.toml
+++ b/lib/rhdl/codegen/netlist/sim/netlist_jit/.cargo/config.toml
@@ -1,0 +1,8 @@
+# macOS linker flags for Ruby native extensions
+# Allows undefined symbols that get resolved at runtime when loaded by Ruby
+
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]


### PR DESCRIPTION
Add .cargo/config.toml to all Rust projects with linker flags that allow undefined symbols on macOS. These symbols are resolved at runtime when the native extension is loaded by Ruby.

This fixes the build on macOS where Magnus/rb-sys requires -undefined dynamic_lookup to link properly.