### PR TITLE
Add speaker audio simulation to Apple II HDL harness

### DIFF
--- a/examples/apple2/bin/apple2
+++ b/examples/apple2/bin/apple2
@@ -71,6 +71,7 @@ class Apple2HDLTerminal
     @green_screen = options[:green] || false
     @hires_mode = options[:hires] || false
     @hires_width = options[:hires_width] || 80
+    @audio_enabled = options[:audio] || false
 
     # Terminal size and padding for centering
     @term_rows = 24
@@ -220,9 +221,15 @@ class Apple2HDLTerminal
     if @sim_type == :netlist
       puts "Using native Rust backend: #{@runner.native?}"
     end
+    if @audio_enabled
+      puts "Audio output: #{RHDL::Apple2::Speaker.available? ? 'enabled' : 'not available (install sox or ffmpeg)'}"
+    end
     puts "WARNING: Both modes are slow (for verification/testing)"
     puts "Press Ctrl+C to exit"
     sleep 1
+
+    # Start audio if enabled
+    @runner.start_audio if @audio_enabled
 
     @runner.reset
 
@@ -428,11 +435,13 @@ class Apple2HDLTerminal
                      format_hz(@current_hz), @fps,
                      format_number(@cycles_per_frame))
 
-      # Line 3: Disk / Key / keyboard mode
-      line3 = format("Disk:T%02d %s | Key:%-3s | KB:%s",
+      # Line 3: Disk / Key / keyboard mode / Audio
+      spk = @runner.speaker
+      audio_status = @audio_enabled ? (spk.active? ? "PLAY" : spk.status) : "off"
+      line3 = format("Disk:T%02d %s|Key:%-3s|KB:%s|Aud:%s",
                      dc.track, dc.motor_on ? "ON " : "OFF",
                      format_key(@last_key),
-                     kb_mode)
+                     kb_mode, audio_status)
 
       # Line 4: Help
       line4 = "ESC:toggle cmd mode | H:toggle hires | Arrows:speed"
@@ -510,14 +519,16 @@ class Apple2HDLTerminal
                      format_hz(@current_hz), @fps,
                      format_number(@cycles_per_frame))
 
-      # Line 3: Disk / Key / keyboard mode
-      line3 = format("Disk:T%02d %s|Key:%-3s|KB:%s",
+      # Line 3: Disk / Key / keyboard mode / Audio
+      spk = @runner.speaker
+      audio_status = @audio_enabled ? (spk.active? ? "PLAY" : spk.status) : "off"
+      line3 = format("Disk:T%02d %s|Key:%-3s|KB:%s|Aud:%s",
                      dc.track, dc.motor_on ? "ON " : "OFF",
                      format_key(@last_key),
-                     kb_mode)
+                     kb_mode, audio_status)
 
       # Line 4: Help
-      line4 = "ESC:cmd mode|H:hires|Arrows:speed"
+      line4 = "ESC:cmd|H:hires|Arrows:spd"
 
       # Pad/truncate lines to fit within border
       line1 = line1.ljust(SCREEN_COLS)[0, SCREEN_COLS]
@@ -633,6 +644,9 @@ class Apple2HDLTerminal
   end
 
   def cleanup
+    # Stop audio
+    @runner.stop_audio if @audio_enabled
+
     print SHOW_CURSOR
     print NORMAL_VIDEO
     # Position exit message below the display area
@@ -704,6 +718,7 @@ options = {
   demo: false,
   hires: false,
   hires_width: 80,
+  audio: false,  # Audio output disabled by default
   mode: :hdl,  # Simulation mode: :hdl (default), :netlist
   sim: :jit   # Simulator backend: :interpret, :jit (default), :compile
 }
@@ -732,6 +747,10 @@ parser = OptionParser.new do |opts|
 
   opts.on("-g", "--green", "Green phosphor effect") do
     options[:green] = true
+  end
+
+  opts.on("-A", "--audio", "Enable speaker audio output") do
+    options[:audio] = true
   end
 
   opts.on("-m", "--mode TYPE", [:hdl, :netlist], "Simulation mode: hdl (default), netlist (gate-level)") do |v|

--- a/examples/apple2/utilities/harness.rb
+++ b/examples/apple2/utilities/harness.rb
@@ -4,6 +4,7 @@
 # Wraps the Apple2 HDL component for use in emulation
 
 require_relative '../hdl/apple2'
+require_relative 'speaker'
 
 module RHDL
   module Apple2
@@ -60,6 +61,10 @@ module RHDL
 
         # Track Q3 for cycle counting
         @prev_q3 = 0
+
+        # Speaker audio simulation
+        @speaker = Speaker.new
+        @prev_speaker_state = 0
       end
 
       # Load ROM data into the Apple2 component
@@ -184,6 +189,13 @@ module RHDL
         # Check for keyboard strobe clear
         if @apple2.get_output(:read_key) == 1
           @key_ready = false
+        end
+
+        # Monitor speaker output for state changes
+        speaker_state = @apple2.get_output(:speaker)
+        if speaker_state != @prev_speaker_state
+          @speaker.toggle
+          @prev_speaker_state = speaker_state
         end
       end
 
@@ -375,7 +387,7 @@ module RHDL
       end
 
       def speaker
-        @speaker ||= SpeakerStub.new
+        @speaker
       end
 
       def display_mode
@@ -383,11 +395,11 @@ module RHDL
       end
 
       def start_audio
-        # No-op for now
+        @speaker.start
       end
 
       def stop_audio
-        # No-op for now
+        @speaker.stop
       end
 
       def read(addr)

--- a/examples/apple2/utilities/speaker.rb
+++ b/examples/apple2/utilities/speaker.rb
@@ -1,0 +1,332 @@
+# frozen_string_literal: true
+
+# Apple II Speaker Simulation for HDL Harness
+# Generates audio from speaker state changes in the HDL simulation
+
+module RHDL
+  module Apple2
+    # Speaker simulation that converts HDL speaker state changes to audio
+    # Uses external audio tools (sox, ffplay, paplay, aplay) for playback
+    class Speaker
+      # Audio sample rate (standard)
+      SAMPLE_RATE = 22050
+
+      # Buffer size in samples (smaller = lower latency, larger = more stable)
+      BUFFER_SIZE = 512
+
+      # Maximum amplitude for 16-bit signed audio
+      AMPLITUDE = 12000
+
+      # Minimum time between toggles to count as audio (filter noise)
+      MIN_TOGGLE_INTERVAL = 0.00001  # 10 microseconds (100kHz max)
+
+      # Maximum time between toggles before we consider it silence
+      MAX_TOGGLE_INTERVAL = 0.1  # 100ms
+
+      attr_reader :enabled, :toggle_count, :audio_backend, :samples_written, :last_error
+
+      def initialize
+        @enabled = false  # Start disabled, enable explicitly
+        @speaker_state = false  # Audio output state: false = low, true = high
+        @prev_hdl_state = false  # Track previous HDL output for update_state
+        @last_toggle_time = nil
+        @sample_buffer = []
+        @sample_position = 0.0
+        @audio_thread = nil
+        @mutex = Mutex.new
+        @running = false
+        @audio_pipe = nil
+        @audio_cmd = nil
+        @audio_backend = nil
+        @toggle_count = 0
+        @samples_generated = 0
+        @samples_written = 0
+        @last_error = nil
+        @last_toggle_count = 0
+        @last_activity_check = Time.now
+      end
+
+      # Update speaker state from HDL output
+      # Called each cycle with the current speaker output value
+      # @param state [Integer] 0 or 1 from the HDL speaker output
+      def update_state(state)
+        new_state = state != 0
+        if new_state != @prev_hdl_state
+          @prev_hdl_state = new_state
+          toggle
+        end
+      end
+
+      # Toggle the speaker (called when state changes)
+      def toggle
+        @toggle_count += 1
+        @speaker_state = !@speaker_state
+        return unless @enabled && @running
+
+        now = Time.now
+        if @last_toggle_time
+          interval = now - @last_toggle_time
+
+          # Only generate audio for reasonable toggle frequencies
+          if interval > MIN_TOGGLE_INTERVAL && interval < MAX_TOGGLE_INTERVAL
+            generate_samples(interval)
+          end
+        end
+
+        @last_toggle_time = now
+      end
+
+      # Generate audio samples for a time interval
+      def generate_samples(interval)
+        num_samples = (interval * SAMPLE_RATE).to_i
+        return if num_samples <= 0 || num_samples > SAMPLE_RATE  # Sanity check
+
+        sample_value = @speaker_state ? AMPLITUDE : -AMPLITUDE
+
+        @mutex.synchronize do
+          num_samples.times do
+            @sample_buffer << sample_value
+          end
+          @samples_generated += num_samples
+
+          # Write to audio pipe if we have enough samples
+          flush_to_pipe if @sample_buffer.size >= BUFFER_SIZE
+        end
+      end
+
+      # Start audio playback
+      def start
+        return if @running
+
+        @audio_cmd, @audio_backend = find_audio_command
+        unless @audio_cmd
+          @audio_backend = 'none'
+          return
+        end
+
+        @running = true
+        @enabled = true
+        @last_toggle_time = nil
+        @toggle_count = 0
+        @samples_generated = 0
+        start_audio_pipe
+      end
+
+      # Stop audio playback
+      def stop
+        return unless @running
+
+        @running = false
+        @enabled = false
+        stop_audio_pipe
+      end
+
+      # Enable/disable audio
+      def enable(state)
+        @enabled = state
+      end
+
+      # Get status info for debug display
+      def status
+        if @running && @audio_backend && @audio_backend != 'none'
+          @audio_backend
+        elsif @audio_backend == 'none'
+          "no backend"
+        else
+          "OFF"
+        end
+      end
+
+      # Check if speaker is actively being toggled (for debug display)
+      def active?
+        now = Time.now
+        if now - @last_activity_check > 0.1
+          @activity = @toggle_count > @last_toggle_count
+          @last_toggle_count = @toggle_count
+          @last_activity_check = now
+        end
+        @activity || false
+      end
+
+      # Get detailed status for debugging
+      def debug_info
+        {
+          backend: @audio_backend,
+          enabled: @enabled,
+          running: @running,
+          toggle_count: @toggle_count,
+          samples_generated: @samples_generated,
+          samples_written: @samples_written,
+          buffer_size: @sample_buffer.size,
+          last_error: @last_error,
+          pipe_open: !@audio_pipe.nil?
+        }
+      end
+
+      # Check if audio system is available
+      def self.available?
+        find_available_backend != nil
+      end
+
+      # Find available audio backend (class method for checking availability)
+      def self.find_available_backend
+        # Check for sox play (works on macOS and Linux)
+        if system('which play > /dev/null 2>&1')
+          return 'sox'
+        end
+
+        # Check for ffplay (ffmpeg - works on macOS and Linux)
+        if system('which ffplay > /dev/null 2>&1')
+          return 'ffplay'
+        end
+
+        # Check for paplay (PulseAudio - Linux)
+        if system('which paplay > /dev/null 2>&1')
+          return 'paplay'
+        end
+
+        # Check for aplay (ALSA - Linux)
+        if system('which aplay > /dev/null 2>&1')
+          return 'aplay'
+        end
+
+        nil
+      end
+
+      private
+
+      def find_audio_command
+        # Detect OS for platform-specific options
+        is_macos = RUBY_PLATFORM =~ /darwin/
+
+        # Try sox play first (cross-platform, install with: brew install sox)
+        if system('which play > /dev/null 2>&1')
+          # sox play reads raw audio from stdin
+          # -t raw: input type is raw PCM
+          # -r: sample rate
+          # -b 16: 16-bit samples
+          # -c 1: mono
+          # -e signed: signed integer encoding
+          # -L: little-endian
+          # -: read from stdin
+          if is_macos
+            cmd = ['play', '-q', '-t', 'raw', '-r', SAMPLE_RATE.to_s,
+                   '-b', '16', '-c', '1', '-e', 'signed', '-L', '-']
+          else
+            cmd = ['play', '-q', '-t', 'raw', '-r', SAMPLE_RATE.to_s,
+                   '-b', '16', '-c', '1', '-e', 'signed', '-L', '-']
+          end
+          return [cmd, 'sox']
+        end
+
+        # Try ffplay (ffmpeg - cross-platform, install with: brew install ffmpeg)
+        if system('which ffplay > /dev/null 2>&1')
+          cmd = ['ffplay', '-f', 's16le', '-ar', SAMPLE_RATE.to_s,
+                 '-ac', '1', '-nodisp', '-autoexit', '-loglevel', 'quiet', '-i', '-']
+          return [cmd, 'ffplay']
+        end
+
+        # Try paplay (PulseAudio - Linux)
+        if system('which paplay > /dev/null 2>&1')
+          cmd = ['paplay', '--raw', "--rate=#{SAMPLE_RATE}", '--channels=1', '--format=s16le']
+          return [cmd, 'paplay']
+        end
+
+        # Try aplay (ALSA - Linux)
+        if system('which aplay > /dev/null 2>&1')
+          cmd = ['aplay', '-q', '-f', 'S16_LE', '-r', SAMPLE_RATE.to_s, '-c', '1']
+          return [cmd, 'aplay']
+        end
+
+        [nil, nil]
+      end
+
+      def start_audio_pipe
+        return unless @audio_cmd
+
+        begin
+          @audio_pipe = IO.popen(@audio_cmd, 'wb')
+          @audio_thread = Thread.new { audio_writer_thread }
+        rescue => e
+          warn "Failed to start audio: #{e.message}" if ENV['DEBUG']
+          @audio_pipe = nil
+          @audio_backend = 'error'
+        end
+      end
+
+      def stop_audio_pipe
+        @audio_thread&.kill
+        @audio_thread = nil
+
+        if @audio_pipe
+          begin
+            @audio_pipe.close
+          rescue
+            nil
+          end
+          @audio_pipe = nil
+        end
+      end
+
+      def audio_writer_thread
+        while @running
+          samples = nil
+
+          @mutex.synchronize do
+            if @sample_buffer.size >= BUFFER_SIZE
+              samples = @sample_buffer.shift(BUFFER_SIZE)
+            end
+          end
+
+          if samples
+            write_samples(samples)
+          else
+            # No samples - sleep briefly
+            sleep 0.01
+          end
+        end
+      end
+
+      def flush_to_pipe
+        # Called within mutex - extract samples and write
+        return unless @audio_pipe && @sample_buffer.size >= BUFFER_SIZE
+
+        samples = @sample_buffer.shift(BUFFER_SIZE)
+        write_samples_unlocked(samples)
+      end
+
+      def write_samples(samples)
+        return unless @audio_pipe && !samples.empty?
+
+        begin
+          raw_data = samples.pack('s<*')
+          @audio_pipe.write(raw_data)
+          @audio_pipe.flush
+          @samples_written += samples.size
+        rescue Errno::EPIPE, IOError => e
+          @last_error = "Pipe: #{e.message}"
+          warn "Audio pipe error: #{e.message}" if ENV['DEBUG']
+          # Restart the pipe
+          stop_audio_pipe
+          start_audio_pipe
+        rescue => e
+          @last_error = "Write: #{e.class}"
+        end
+      end
+
+      def write_samples_unlocked(samples)
+        return unless @audio_pipe && !samples.empty?
+
+        begin
+          raw_data = samples.pack('s<*')
+          @audio_pipe.write(raw_data)
+          @samples_written += samples.size
+        rescue Errno::EPIPE, IOError => e
+          @last_error = "Pipe: #{e.message}"
+        rescue => e
+          @last_error = "Write: #{e.class}"
+        end
+      end
+    end
+  end
+end

--- a/lib/rhdl/cli/tasks/apple2_task.rb
+++ b/lib/rhdl/cli/tasks/apple2_task.rb
@@ -147,6 +147,7 @@ module RHDL
           end
           exec_args.push("-s", options[:speed].to_s) if options[:speed]
           exec_args << "-g" if options[:green]
+          exec_args << "-A" if options[:audio]
           exec_args << "-H" if options[:hires]
           exec_args.push("--hires-width", options[:hires_width].to_s) if options[:hires_width]
           exec_args.push("--disk", options[:disk]) if options[:disk]

--- a/spec/examples/apple2/speaker_spec.rb
+++ b/spec/examples/apple2/speaker_spec.rb
@@ -1,0 +1,209 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../../examples/apple2/utilities/speaker'
+
+RSpec.describe RHDL::Apple2::Speaker do
+  let(:speaker) { described_class.new }
+
+  describe '#initialize' do
+    it 'starts disabled' do
+      expect(speaker.enabled).to be false
+    end
+
+    it 'has zero toggle count initially' do
+      expect(speaker.toggle_count).to eq(0)
+    end
+
+    it 'has no audio backend initially' do
+      expect(speaker.audio_backend).to be_nil
+    end
+  end
+
+  describe '#toggle' do
+    context 'when not running' do
+      it 'increments toggle count' do
+        expect { speaker.toggle }.to change { speaker.toggle_count }.by(1)
+      end
+
+      it 'does not generate samples' do
+        speaker.toggle
+        expect(speaker.samples_written).to eq(0)
+      end
+    end
+  end
+
+  describe '#update_state' do
+    it 'toggles on state change from 0 to 1' do
+      speaker.update_state(0)
+      expect { speaker.update_state(1) }.to change { speaker.toggle_count }.by(1)
+    end
+
+    it 'toggles on state change from 1 to 0' do
+      speaker.update_state(1)
+      expect { speaker.update_state(0) }.to change { speaker.toggle_count }.by(1)
+    end
+
+    it 'does not toggle when state unchanged' do
+      speaker.update_state(0)
+      expect { speaker.update_state(0) }.not_to change { speaker.toggle_count }
+    end
+  end
+
+  describe '#status' do
+    it 'returns "OFF" when not running' do
+      expect(speaker.status).to eq("OFF")
+    end
+
+    it 'returns "no backend" when started but no audio available' do
+      # Mock no audio backend available
+      allow(speaker).to receive(:find_audio_command).and_return([nil, nil])
+      speaker.start
+      expect(speaker.status).to eq("no backend")
+    end
+  end
+
+  describe '#active?' do
+    it 'returns false when no toggles' do
+      expect(speaker.active?).to be false
+    end
+
+    it 'returns true when speaker has been toggled recently' do
+      # First check sets the baseline
+      speaker.active?
+      # Toggle the speaker
+      10.times { speaker.toggle }
+      # Force activity check by sleeping
+      speaker.instance_variable_set(:@last_activity_check, Time.now - 0.2)
+      expect(speaker.active?).to be true
+    end
+  end
+
+  describe '#debug_info' do
+    it 'returns a hash with status information' do
+      info = speaker.debug_info
+      expect(info).to be_a(Hash)
+      expect(info).to include(
+        :backend,
+        :enabled,
+        :running,
+        :toggle_count,
+        :samples_generated,
+        :samples_written,
+        :buffer_size,
+        :last_error,
+        :pipe_open
+      )
+    end
+  end
+
+  describe '.available?' do
+    it 'returns a boolean' do
+      result = described_class.available?
+      expect([true, false]).to include(result)
+    end
+  end
+
+  describe '.find_available_backend' do
+    it 'returns nil or a valid backend name' do
+      result = described_class.find_available_backend
+      expect([nil, 'sox', 'ffplay', 'paplay', 'aplay']).to include(result)
+    end
+  end
+
+  describe '#start and #stop' do
+    context 'when no audio backend available' do
+      before do
+        allow(speaker).to receive(:find_audio_command).and_return([nil, nil])
+      end
+
+      it 'sets backend to none on start' do
+        speaker.start
+        expect(speaker.audio_backend).to eq('none')
+      end
+    end
+
+    it 'can be stopped without starting' do
+      expect { speaker.stop }.not_to raise_error
+    end
+  end
+
+  describe '#enable' do
+    it 'enables the speaker' do
+      speaker.enable(true)
+      expect(speaker.enabled).to be true
+    end
+
+    it 'disables the speaker' do
+      speaker.enable(true)
+      speaker.enable(false)
+      expect(speaker.enabled).to be false
+    end
+  end
+
+  describe 'sample generation' do
+    it 'calculates correct sample count for interval' do
+      # At 22050 Hz, 0.001 seconds = ~22 samples
+      interval = 0.001
+      expected_samples = (interval * described_class::SAMPLE_RATE).to_i
+
+      # Enable generation path
+      speaker.instance_variable_set(:@running, true)
+      speaker.instance_variable_set(:@enabled, true)
+      speaker.instance_variable_set(:@last_toggle_time, Time.now - interval)
+      speaker.instance_variable_set(:@speaker_state, true)
+
+      # Create a mock mutex to allow sample generation
+      speaker.instance_variable_set(:@mutex, Mutex.new)
+      speaker.instance_variable_set(:@sample_buffer, [])
+      speaker.instance_variable_set(:@audio_pipe, nil)  # Prevent flush
+
+      speaker.send(:generate_samples, interval)
+
+      buffer = speaker.instance_variable_get(:@sample_buffer)
+      expect(buffer.size).to eq(expected_samples)
+    end
+
+    it 'generates positive amplitude when speaker state is true' do
+      speaker.instance_variable_set(:@running, true)
+      speaker.instance_variable_set(:@enabled, true)
+      speaker.instance_variable_set(:@speaker_state, true)
+      speaker.instance_variable_set(:@mutex, Mutex.new)
+      speaker.instance_variable_set(:@sample_buffer, [])
+      speaker.instance_variable_set(:@audio_pipe, nil)
+
+      speaker.send(:generate_samples, 0.001)
+
+      buffer = speaker.instance_variable_get(:@sample_buffer)
+      expect(buffer.first).to eq(described_class::AMPLITUDE)
+    end
+
+    it 'generates negative amplitude when speaker state is false' do
+      speaker.instance_variable_set(:@running, true)
+      speaker.instance_variable_set(:@enabled, true)
+      speaker.instance_variable_set(:@speaker_state, false)
+      speaker.instance_variable_set(:@mutex, Mutex.new)
+      speaker.instance_variable_set(:@sample_buffer, [])
+      speaker.instance_variable_set(:@audio_pipe, nil)
+
+      speaker.send(:generate_samples, 0.001)
+
+      buffer = speaker.instance_variable_get(:@sample_buffer)
+      expect(buffer.first).to eq(-described_class::AMPLITUDE)
+    end
+  end
+
+  describe 'constants' do
+    it 'has a reasonable sample rate' do
+      expect(described_class::SAMPLE_RATE).to eq(22050)
+    end
+
+    it 'has a reasonable buffer size' do
+      expect(described_class::BUFFER_SIZE).to eq(512)
+    end
+
+    it 'has amplitude within 16-bit signed range' do
+      expect(described_class::AMPLITUDE).to be_between(0, 32767)
+    end
+  end
+end


### PR DESCRIPTION
Implements real-time audio output for the Apple II emulator by monitoring the HDL speaker output signal and generating PCM audio via external tools (sox, ffplay, paplay, or aplay).

Changes:
- Add Speaker class that converts speaker state changes to audio samples
- Integrate speaker monitoring in HDL Runner's 14MHz cycle loop
- Add --audio/-A flag to enable audio in the terminal emulator
- Show audio status in debug display panel
- Add comprehensive specs for the Speaker class

https://claude.ai/code/session_013Xj5QW1XjP87ucR91vczSm