### PR TITLE
Auto-compile in IrCompilerWrapper for performance

### DIFF
--- a/lib/rhdl/codegen/ir/sim/ir_compiler.rb
+++ b/lib/rhdl/codegen/ir/sim/ir_compiler.rb
@@ -50,6 +50,8 @@ module RHDL
           end
 
           @sim = IrCompiler.new(ir_json)
+          # Auto-compile for performance - without this, falls back to slow interpreted mode
+          @sim.compile
         end
 
         def simulator_type


### PR DESCRIPTION
The compiler backend was falling back to slow interpreted mode because compile() wasn't being called automatically. Now compile() is called during initialization to ensure the compiled native code is used.

Without this fix: ~50Hz (interpreted)
With this fix: should match or exceed JIT speed (>200kHz)