### PR TITLE
Add MOS6502 ISA vs Apple2 comparison tests

### DIFF
--- a/examples/apple2/hdl/apple2.rb
+++ b/examples/apple2/hdl/apple2.rb
@@ -313,8 +313,9 @@ module RHDL
                      (a_hi == lit(0xE, width: 4)) |
                      (a_hi == lit(0xF, width: 4))
 
-        # RAM select: $0000-$BFFF
-        ram_select = ~cpu_addr[15] | (~cpu_addr[14] & ~cpu_addr[15])
+        # RAM select: $0000-$BFFF (not $C000-$FFFF)
+        # True when address bits 15 and 14 are not both 1
+        ram_select = ~cpu_addr[15] | ~cpu_addr[14]
 
         # Keyboard select: $C000-$C00F
         keyboard_select = (a_hi == lit(0xC, width: 4)) &


### PR DESCRIPTION
Add 6 new tests that compare the MOS6502 ISA simulator (reference)
against the Apple2 IR simulators (target) to ensure both systems
produce the same results:

AppleIIGo ROM only:
- Ruby ISA vs IR interpreter (1k iterations)
- Rust ISA vs IR interpreter (1k iterations)
- Rust ISA vs IR JIT (100k iterations)

Karateka memory dump:
- Ruby ISA vs IR interpreter (1k iterations)
- Rust ISA vs IR interpreter (1k iterations)
- Rust ISA vs IR JIT (100k iterations)

The interpreter tests use fewer iterations (1k) due to performance,
while JIT tests can run 100k iterations efficiently.

https://claude.ai/code/session_01KFQLbySYHiu2eLoTZ4C1H5