### PR TITLE
Add NTSC artifact color rendering for Apple II hires mode

### DIFF
--- a/examples/apple2/bin/apple2
+++ b/examples/apple2/bin/apple2
@@ -73,7 +73,9 @@ class Apple2HDLTerminal
     @debug = options[:debug] || false
     @green_screen = options[:green] || false
     @hires_mode = options[:hires] || false
-    @hires_width = options[:hires_width] || 80
+    @color_mode = options[:color] || false
+    # Default width is 140 for color mode (half-blocks), 80 for braille
+    @hires_width = options[:hires_width] || (@color_mode ? 140 : 80)
     @audio_enabled = options[:audio] || false
 
     # Terminal size and padding for centering
@@ -383,6 +385,12 @@ class Apple2HDLTerminal
     when 72, 104 # H or h - toggle hires mode
       @hires_mode = !@hires_mode
       print CLEAR_SCREEN
+    when 67, 99 # C or c - toggle color mode
+      @color_mode = !@color_mode
+      @hires_mode = true if @color_mode  # Color implies hires
+      # Adjust width for the mode
+      @hires_width = @color_mode ? 140 : 80
+      print CLEAR_SCREEN
     end
   end
 
@@ -397,13 +405,17 @@ class Apple2HDLTerminal
   def render_hires_screen
     output = String.new
 
-    if @green_screen
+    if @green_screen && !@color_mode
       output << GREEN_FG
       output << BLACK_BG
     end
 
-    # Render hi-res using braille characters
-    hires_output = @runner.render_hires_braille(chars_wide: @hires_width, invert: true)
+    # Render hi-res using color or braille characters
+    if @color_mode
+      hires_output = @runner.render_hires_color(chars_wide: @hires_width)
+    else
+      hires_output = @runner.render_hires_braille(chars_wide: @hires_width, invert: true)
+    end
     hires_lines = hires_output.split("\n")
 
     # Render each line of hires output with proper centering
@@ -424,9 +436,10 @@ class Apple2HDLTerminal
       kb_mode = @keyboard_mode == :command ? "CMD" : "NRM"
 
       # Line 1: Registers
-      line1 = format("PC:%04X A:%02X X:%02X Y:%02X SP:%02X P:%02X [HIRES]",
+      mode_label = @color_mode ? "[COLOR]" : "[HIRES]"
+      line1 = format("PC:%04X A:%02X X:%02X Y:%02X SP:%02X P:%02X %s",
                      state[:pc], state[:a], state[:x], state[:y],
-                     state[:sp], state[:p] || 0)
+                     state[:sp], state[:p] || 0, mode_label)
 
       # Line 2: Sim type / cycles / speed
       line2 = format("Sim:%-7s Cyc:%s %s %.1ffps Spd:%s",
@@ -444,7 +457,7 @@ class Apple2HDLTerminal
                      kb_mode, audio_status)
 
       # Line 4: Help
-      line4 = "ESC:toggle cmd mode | H:toggle hires | Arrows:speed"
+      line4 = "ESC:cmd | H:hires | C:color | Arrows:speed"
 
       # Pad/truncate lines to fit within border
       line1 = line1.ljust(debug_width)[0, debug_width]
@@ -718,6 +731,7 @@ options = {
   demo: false,
   hires: false,
   hires_width: 80,
+  color: false,  # NTSC artifact color rendering
   audio: false,  # Audio output disabled by default
   mode: :hdl,  # Simulation mode: :hdl (default), :netlist
   sim: :ruby   # Simulator backend: :ruby (default), :interpret, :jit, :compile
@@ -765,7 +779,12 @@ parser = OptionParser.new do |opts|
     options[:hires] = true
   end
 
-  opts.on("--hires-width WIDTH", Integer, "Hi-res display width in chars (default: 80)") do |v|
+  opts.on("-C", "--color", "Enable NTSC artifact color rendering (implies --hires)") do
+    options[:color] = true
+    options[:hires] = true
+  end
+
+  opts.on("--hires-width WIDTH", Integer, "Hi-res display width in chars (default: 80, 140 for color)") do |v|
     options[:hires_width] = v
   end
 
@@ -785,9 +804,10 @@ parser = OptionParser.new do |opts|
     options[:pc] = v.to_i(16)
   end
 
-  opts.on("--karateka", "Load Karateka memory dump") do
+  opts.on("--karateka", "Load Karateka memory dump (enables color mode)") do
     options[:karateka] = true
-    options[:hires] = true  # Karateka uses hi-res graphics
+    options[:hires] = true   # Karateka uses hi-res graphics
+    options[:color] = true   # Enable NTSC artifact colors
   end
 
   opts.on("--disk FILE", "Load disk image (.dsk)") do |v|

--- a/examples/apple2/utilities/braille_renderer.rb
+++ b/examples/apple2/utilities/braille_renderer.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+# Apple II Hi-Res Braille Renderer
+# Renders Apple II hi-res screen using Unicode braille characters (2x4 dots per char)
+
+module RHDL
+  module Apple2
+    # Renders Apple II hi-res graphics using Unicode braille characters
+    # Each braille character is 2 dots wide x 4 dots tall, providing
+    # high-resolution monochrome display in terminal
+    class BrailleRenderer
+      HIRES_WIDTH = 280   # pixels
+      HIRES_HEIGHT = 192  # lines
+
+      # ANSI escape codes
+      ESC = "\e"
+      GREEN_FG = "#{ESC}[32m"
+      BLACK_BG = "#{ESC}[40m"
+      NORMAL_VIDEO = "#{ESC}[0m"
+
+      # Braille dot positions (Unicode mapping):
+      # Dot 1 (0x01) Dot 4 (0x08)
+      # Dot 2 (0x02) Dot 5 (0x10)
+      # Dot 3 (0x04) Dot 6 (0x20)
+      # Dot 7 (0x40) Dot 8 (0x80)
+      DOT_MAP = [
+        [0x01, 0x08],  # row 0
+        [0x02, 0x10],  # row 1
+        [0x04, 0x20],  # row 2
+        [0x40, 0x80]   # row 3
+      ].freeze
+
+      def initialize(options = {})
+        @green_screen = options[:green] || false
+        @invert = options[:invert] || false
+        @chars_wide = options[:chars_wide] || 80
+      end
+
+      # Render hi-res bitmap to braille string
+      # bitmap: 2D array of 0/1 values (192 rows x 280 pixels)
+      # Returns multi-line string of braille characters
+      def render(bitmap, chars_wide: @chars_wide, invert: @invert)
+        # Braille characters are 2 dots wide x 4 dots tall
+        chars_tall = (HIRES_HEIGHT / 4.0).ceil
+
+        # Scale factors
+        x_scale = HIRES_WIDTH.to_f / (chars_wide * 2)
+        y_scale = HIRES_HEIGHT.to_f / (chars_tall * 4)
+
+        output = String.new
+        output << GREEN_FG << BLACK_BG if @green_screen
+
+        lines = []
+        chars_tall.times do |char_y|
+          line = String.new
+          chars_wide.times do |char_x|
+            pattern = 0
+
+            # Sample 2x4 grid for this braille character
+            4.times do |dy|
+              2.times do |dx|
+                px = ((char_x * 2 + dx) * x_scale).to_i
+                py = ((char_y * 4 + dy) * y_scale).to_i
+                px = [px, HIRES_WIDTH - 1].min
+                py = [py, HIRES_HEIGHT - 1].min
+
+                pixel = bitmap[py][px]
+                pixel = 1 - pixel if invert
+                pattern |= DOT_MAP[dy][dx] if pixel == 1
+              end
+            end
+
+            # Unicode braille starts at U+2800
+            line << (0x2800 + pattern).chr(Encoding::UTF_8)
+          end
+          lines << line
+        end
+
+        output << lines.join("\n")
+        output << NORMAL_VIDEO if @green_screen
+
+        output
+      end
+
+      # Render to array of lines (without newlines)
+      def render_lines(bitmap, chars_wide: @chars_wide, invert: @invert)
+        render(bitmap, chars_wide: chars_wide, invert: invert).split("\n")
+      end
+    end
+  end
+end

--- a/examples/apple2/utilities/color_renderer.rb
+++ b/examples/apple2/utilities/color_renderer.rb
@@ -1,0 +1,233 @@
+# frozen_string_literal: true
+
+# Apple II Hi-Res Color Renderer
+# Renders Apple II hi-res screen with NTSC artifact colors
+#
+# The Apple II produces color through NTSC artifact coloring:
+# - Pixels at 7.16 MHz (2x NTSC colorburst at 3.58 MHz)
+# - Adjacent pixels of different phases produce colors
+# - Bit 7 of each byte selects between two color palettes:
+#   - Palette 0 (bit7=0): Black, Green, Purple, White
+#   - Palette 1 (bit7=1): Black, Orange, Blue, White
+
+module RHDL
+  module Apple2
+    # Renders Apple II hi-res graphics with NTSC artifact colors
+    # Uses 3-bit sliding window algorithm for color determination
+    class ColorRenderer
+      HIRES_WIDTH = 280   # pixels
+      HIRES_HEIGHT = 192  # lines
+      HIRES_BYTES_PER_LINE = 40
+
+      # ANSI escape codes
+      ESC = "\e"
+      NORMAL_VIDEO = "#{ESC}[0m"
+
+      # HiRes color palette (RGB values)
+      # These values are commonly used in Apple II emulators
+      COLORS = {
+        black:  [0x00, 0x00, 0x00],
+        white:  [0xFF, 0xFF, 0xFF],
+        green:  [0x14, 0xF5, 0x3C],  # NTSC artifact green
+        purple: [0xD6, 0x60, 0xEF],  # NTSC artifact purple/violet
+        orange: [0xFF, 0x6A, 0x3C],  # NTSC artifact orange
+        blue:   [0x14, 0xCF, 0xFD]   # NTSC artifact blue
+      }.freeze
+
+      # Half-block characters for rendering
+      UPPER_HALF = "\u2580"  # Upper half block
+      LOWER_HALF = "\u2584"  # Lower half block
+      FULL_BLOCK = "\u2588"  # Full block
+
+      def initialize(options = {})
+        @chars_wide = options[:chars_wide] || 140
+      end
+
+      # Render hi-res memory to colored string
+      # ram: memory array with hi-res data
+      # base_addr: base address of hi-res page (0x2000 for page 1)
+      # Returns multi-line string with ANSI color codes
+      def render(ram, base_addr: 0x2000, chars_wide: @chars_wide)
+        # First, decode the bitmap with color information
+        color_bitmap = decode_hires_colors(ram, base_addr)
+
+        # Render using half-block characters (2 rows per character)
+        render_half_blocks(color_bitmap, chars_wide)
+      end
+
+      # Decode hi-res memory into a color bitmap
+      # Returns 2D array of color symbols (192 rows x 280 pixels)
+      def decode_hires_colors(ram, base_addr)
+        bitmap = []
+
+        HIRES_HEIGHT.times do |row|
+          line = []
+          line_addr = hires_line_address(row, base_addr)
+
+          # Process each byte in the line
+          HIRES_BYTES_PER_LINE.times do |col|
+            byte = ram[line_addr + col] || 0
+            high_bit = (byte >> 7) & 1  # Palette select
+
+            # Get previous byte's last pixel for sliding window
+            prev_byte = col > 0 ? (ram[line_addr + col - 1] || 0) : 0
+            prev_pixel = (prev_byte >> 6) & 1
+
+            # Get next byte's first pixel for sliding window
+            next_byte = col < HIRES_BYTES_PER_LINE - 1 ? (ram[line_addr + col + 1] || 0) : 0
+            next_first = next_byte & 1
+
+            # Process 7 pixels in this byte
+            7.times do |bit|
+              curr_pixel = (byte >> bit) & 1
+
+              # Get adjacent pixels for the 3-bit window
+              if bit == 0
+                prev = prev_pixel
+              else
+                prev = (byte >> (bit - 1)) & 1
+              end
+
+              if bit == 6
+                nxt = next_first
+              else
+                nxt = (byte >> (bit + 1)) & 1
+              end
+
+              # Determine color from 3-bit pattern
+              color = determine_color(prev, curr_pixel, nxt, high_bit, col * 7 + bit)
+              line << color
+            end
+          end
+
+          bitmap << line
+        end
+
+        bitmap
+      end
+
+      # Determine pixel color using 3-bit sliding window algorithm
+      # prev: previous pixel (0/1)
+      # curr: current pixel (0/1)
+      # nxt: next pixel (0/1)
+      # high_bit: palette select (0 = green/purple, 1 = blue/orange)
+      # x_pos: horizontal position (for odd/even determination)
+      def determine_color(prev, curr, nxt, high_bit, x_pos)
+        pattern = (prev << 2) | (curr << 1) | nxt
+
+        case pattern
+        when 0b000, 0b001, 0b100
+          # No current pixel lit, or isolated edges -> black
+          :black
+        when 0b011, 0b110, 0b111
+          # Current pixel with neighbor(s) -> white
+          :white
+        when 0b010
+          # Isolated pixel - color depends on position and palette
+          if high_bit == 0
+            x_pos.odd? ? :green : :purple
+          else
+            x_pos.odd? ? :orange : :blue
+          end
+        when 0b101
+          # Gap between two pixels - creates artifact color
+          if high_bit == 0
+            x_pos.odd? ? :purple : :green
+          else
+            x_pos.odd? ? :blue : :orange
+          end
+        else
+          :black
+        end
+      end
+
+      # Render color bitmap using half-block characters
+      # Each terminal character shows 2 vertical pixels
+      def render_half_blocks(color_bitmap, chars_wide)
+        output = String.new
+
+        # Scale factor for horizontal
+        x_scale = HIRES_WIDTH.to_f / chars_wide
+
+        # Process 2 rows at a time (upper/lower half blocks)
+        (HIRES_HEIGHT / 2).times do |char_row|
+          upper_row = char_row * 2
+          lower_row = char_row * 2 + 1
+
+          chars_wide.times do |char_col|
+            # Sample pixel at this position
+            px = (char_col * x_scale).to_i
+            px = [px, HIRES_WIDTH - 1].min
+
+            upper_color = color_bitmap[upper_row][px]
+            lower_color = color_bitmap[lower_row][px]
+
+            # Generate character with appropriate colors
+            output << color_char(upper_color, lower_color)
+          end
+
+          output << NORMAL_VIDEO << "\n"
+        end
+
+        output
+      end
+
+      # Generate a colored character for upper/lower pixel colors
+      def color_char(upper_color, lower_color)
+        upper_rgb = COLORS[upper_color]
+        lower_rgb = COLORS[lower_color]
+
+        if upper_color == lower_color
+          # Same color - use full block or space
+          if upper_color == :black
+            " "
+          else
+            fg_color(upper_rgb) + FULL_BLOCK
+          end
+        elsif upper_color == :black
+          # Only lower pixel lit
+          fg_color(lower_rgb) + LOWER_HALF
+        elsif lower_color == :black
+          # Only upper pixel lit
+          fg_color(upper_rgb) + UPPER_HALF
+        else
+          # Both different colors - use upper half with fg/bg
+          fg_color(upper_rgb) + bg_color(lower_rgb) + UPPER_HALF
+        end
+      end
+
+      # ANSI truecolor foreground escape sequence
+      def fg_color(rgb)
+        "#{ESC}[38;2;#{rgb[0]};#{rgb[1]};#{rgb[2]}m"
+      end
+
+      # ANSI truecolor background escape sequence
+      def bg_color(rgb)
+        "#{ESC}[48;2;#{rgb[0]};#{rgb[1]};#{rgb[2]}m"
+      end
+
+      # Hi-res screen line address calculation (Apple II interleaved layout)
+      def hires_line_address(row, base)
+        # Each group of 8 consecutive rows is separated by 0x400 bytes
+        # Groups of 8 lines within a section are 0x80 apart
+        # Sections (0-63, 64-127, 128-191) are 0x28 apart
+        section = row / 64           # 0, 1, or 2
+        row_in_section = row % 64
+        group = row_in_section / 8   # 0-7
+        line_in_group = row_in_section % 8  # 0-7
+
+        base + (line_in_group * 0x400) + (group * 0x80) + (section * 0x28)
+      end
+
+      # Render to array of lines
+      def render_lines(ram, base_addr: 0x2000, chars_wide: @chars_wide)
+        render(ram, base_addr: base_addr, chars_wide: chars_wide).split("\n")
+      end
+
+      # Class method for quick rendering
+      def self.render(ram, base_addr: 0x2000, chars_wide: 140)
+        new(chars_wide: chars_wide).render(ram, base_addr: base_addr)
+      end
+    end
+  end
+end

--- a/examples/apple2/utilities/text_renderer.rb
+++ b/examples/apple2/utilities/text_renderer.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Apple II Text Mode Renderer
+# Renders Apple II text screen (40x24 characters)
+
+module RHDL
+  module Apple2
+    # Renders Apple II text mode screen to terminal
+    class TextRenderer
+      SCREEN_ROWS = 24
+      SCREEN_COLS = 40
+
+      # ANSI escape codes
+      ESC = "\e"
+      GREEN_FG = "#{ESC}[32m"
+      BLACK_BG = "#{ESC}[40m"
+      NORMAL_VIDEO = "#{ESC}[0m"
+
+      def initialize(options = {})
+        @green_screen = options[:green] || false
+      end
+
+      # Render screen array to string with borders
+      # screen_array: 2D array of character codes (24 rows x 40 cols)
+      def render(screen_array)
+        output = String.new
+
+        output << GREEN_FG << BLACK_BG if @green_screen
+
+        # Border top
+        output << "+" << ("-" * SCREEN_COLS) << "+\n"
+
+        # Screen content
+        screen_array.each do |line|
+          output << "|"
+          line.each do |char_code|
+            char = (char_code & 0x7F).chr
+            char = ' ' if char_code < 0x20
+            output << char
+          end
+          output << "|\n"
+        end
+
+        # Border bottom
+        output << "+" << ("-" * SCREEN_COLS) << "+"
+
+        output << NORMAL_VIDEO if @green_screen
+
+        output
+      end
+
+      # Render to array of lines (without newlines)
+      def render_lines(screen_array)
+        render(screen_array).split("\n")
+      end
+    end
+  end
+end

--- a/spec/examples/apple2/braille_renderer_spec.rb
+++ b/spec/examples/apple2/braille_renderer_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+$LOAD_PATH.unshift File.expand_path('../../../examples/apple2/utilities', __dir__)
+require 'braille_renderer'
+
+RSpec.describe RHDL::Apple2::BrailleRenderer do
+  let(:renderer) { described_class.new }
+
+  # Create a test bitmap (192 rows x 280 pixels)
+  let(:blank_bitmap) do
+    Array.new(192) { Array.new(280, 0) }
+  end
+
+  let(:filled_bitmap) do
+    Array.new(192) { Array.new(280, 1) }
+  end
+
+  describe '#render' do
+    it 'produces output for blank bitmap' do
+      output = renderer.render(blank_bitmap, chars_wide: 40)
+      expect(output).to be_a(String)
+      expect(output.length).to be > 0
+    end
+
+    it 'produces braille characters' do
+      output = renderer.render(blank_bitmap, chars_wide: 40)
+      # Blank braille character is U+2800
+      expect(output).to include("\u2800")
+    end
+
+    it 'produces filled braille for filled bitmap' do
+      output = renderer.render(filled_bitmap, chars_wide: 40, invert: false)
+      # Full braille character is U+28FF
+      expect(output).to include("\u28FF")
+    end
+
+    it 'respects invert option' do
+      inverted_output = renderer.render(blank_bitmap, chars_wide: 40, invert: true)
+      normal_output = renderer.render(blank_bitmap, chars_wide: 40, invert: false)
+      expect(inverted_output).not_to eq(normal_output)
+    end
+
+    it 'produces correct number of lines' do
+      output = renderer.render(blank_bitmap, chars_wide: 40)
+      lines = output.split("\n")
+      # 192 / 4 = 48 braille character rows
+      expect(lines.length).to eq(48)
+    end
+
+    it 'produces correct line width' do
+      output = renderer.render(blank_bitmap, chars_wide: 40)
+      lines = output.split("\n")
+      # Each line should have 40 braille characters
+      expect(lines.first.length).to eq(40)
+    end
+  end
+
+  describe '#render_lines' do
+    it 'returns array of lines' do
+      lines = renderer.render_lines(blank_bitmap, chars_wide: 40)
+      expect(lines).to be_an(Array)
+      expect(lines.length).to eq(48)
+    end
+
+    it 'lines do not contain newlines' do
+      lines = renderer.render_lines(blank_bitmap, chars_wide: 40)
+      lines.each do |line|
+        expect(line).not_to include("\n")
+      end
+    end
+  end
+
+  describe 'green screen mode' do
+    let(:green_renderer) { described_class.new(green: true) }
+
+    it 'includes ANSI green foreground code' do
+      output = green_renderer.render(blank_bitmap, chars_wide: 40)
+      expect(output).to include("\e[32m")
+    end
+
+    it 'includes ANSI black background code' do
+      output = green_renderer.render(blank_bitmap, chars_wide: 40)
+      expect(output).to include("\e[40m")
+    end
+
+    it 'includes ANSI reset code' do
+      output = green_renderer.render(blank_bitmap, chars_wide: 40)
+      expect(output).to include("\e[0m")
+    end
+  end
+
+  describe 'DOT_MAP constant' do
+    it 'defines correct braille dot mappings' do
+      expect(described_class::DOT_MAP[0]).to eq([0x01, 0x08])  # row 0
+      expect(described_class::DOT_MAP[1]).to eq([0x02, 0x10])  # row 1
+      expect(described_class::DOT_MAP[2]).to eq([0x04, 0x20])  # row 2
+      expect(described_class::DOT_MAP[3]).to eq([0x40, 0x80])  # row 3
+    end
+  end
+
+  describe 'scaling' do
+    it 'scales correctly at different widths' do
+      narrow = renderer.render(filled_bitmap, chars_wide: 20)
+      wide = renderer.render(filled_bitmap, chars_wide: 80)
+
+      narrow_lines = narrow.split("\n")
+      wide_lines = wide.split("\n")
+
+      expect(narrow_lines.first.length).to eq(20)
+      expect(wide_lines.first.length).to eq(80)
+    end
+  end
+end

--- a/spec/examples/apple2/color_renderer_spec.rb
+++ b/spec/examples/apple2/color_renderer_spec.rb
@@ -1,0 +1,216 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+$LOAD_PATH.unshift File.expand_path('../../../examples/apple2/utilities', __dir__)
+require 'color_renderer'
+
+RSpec.describe RHDL::Apple2::ColorRenderer do
+  let(:renderer) { described_class.new }
+
+  # Create test RAM with hi-res page at $2000
+  let(:ram) { Array.new(0x6000, 0) }
+
+  describe '#hires_line_address' do
+    it 'calculates correct address for line 0' do
+      expect(renderer.hires_line_address(0, 0x2000)).to eq(0x2000)
+    end
+
+    it 'calculates correct address for line 1' do
+      expect(renderer.hires_line_address(1, 0x2000)).to eq(0x2400)
+    end
+
+    it 'calculates correct address for line 8' do
+      expect(renderer.hires_line_address(8, 0x2000)).to eq(0x2080)
+    end
+
+    it 'calculates correct address for line 64' do
+      expect(renderer.hires_line_address(64, 0x2000)).to eq(0x2028)
+    end
+
+    it 'calculates correct address for line 128' do
+      expect(renderer.hires_line_address(128, 0x2000)).to eq(0x2050)
+    end
+  end
+
+  describe '#determine_color' do
+    context 'with palette 0 (green/purple)' do
+      it 'returns black for pattern 000' do
+        expect(renderer.determine_color(0, 0, 0, 0, 0)).to eq(:black)
+      end
+
+      it 'returns black for pattern 001' do
+        expect(renderer.determine_color(0, 0, 1, 0, 0)).to eq(:black)
+      end
+
+      it 'returns black for pattern 100' do
+        expect(renderer.determine_color(1, 0, 0, 0, 0)).to eq(:black)
+      end
+
+      it 'returns white for pattern 011' do
+        expect(renderer.determine_color(0, 1, 1, 0, 0)).to eq(:white)
+      end
+
+      it 'returns white for pattern 110' do
+        expect(renderer.determine_color(1, 1, 0, 0, 0)).to eq(:white)
+      end
+
+      it 'returns white for pattern 111' do
+        expect(renderer.determine_color(1, 1, 1, 0, 0)).to eq(:white)
+      end
+
+      it 'returns purple for isolated pixel at even position' do
+        expect(renderer.determine_color(0, 1, 0, 0, 0)).to eq(:purple)
+      end
+
+      it 'returns green for isolated pixel at odd position' do
+        expect(renderer.determine_color(0, 1, 0, 0, 1)).to eq(:green)
+      end
+
+      it 'returns green for gap at even position' do
+        expect(renderer.determine_color(1, 0, 1, 0, 0)).to eq(:green)
+      end
+
+      it 'returns purple for gap at odd position' do
+        expect(renderer.determine_color(1, 0, 1, 0, 1)).to eq(:purple)
+      end
+    end
+
+    context 'with palette 1 (blue/orange)' do
+      it 'returns blue for isolated pixel at even position' do
+        expect(renderer.determine_color(0, 1, 0, 1, 0)).to eq(:blue)
+      end
+
+      it 'returns orange for isolated pixel at odd position' do
+        expect(renderer.determine_color(0, 1, 0, 1, 1)).to eq(:orange)
+      end
+
+      it 'returns orange for gap at even position' do
+        expect(renderer.determine_color(1, 0, 1, 1, 0)).to eq(:orange)
+      end
+
+      it 'returns blue for gap at odd position' do
+        expect(renderer.determine_color(1, 0, 1, 1, 1)).to eq(:blue)
+      end
+    end
+  end
+
+  describe '#decode_hires_colors' do
+    it 'decodes all black screen' do
+      bitmap = renderer.decode_hires_colors(ram, 0x2000)
+      expect(bitmap.length).to eq(192)
+      expect(bitmap[0].length).to eq(280)
+      expect(bitmap[0].all? { |c| c == :black }).to be true
+    end
+
+    it 'decodes white pixels for adjacent bits' do
+      # Set first byte of first line to 0x7F (all 7 pixels on, high bit 0)
+      ram[0x2000] = 0x7F
+      bitmap = renderer.decode_hires_colors(ram, 0x2000)
+
+      # All 7 pixels should be white (adjacent pixels)
+      (0...7).each do |i|
+        expect(bitmap[0][i]).to eq(:white), "pixel #{i} should be white"
+      end
+    end
+
+    it 'decodes single purple pixel at even position' do
+      # Isolated pixel at position 0 (even) with high bit 0
+      ram[0x2000] = 0x01  # bit 0 set
+      bitmap = renderer.decode_hires_colors(ram, 0x2000)
+
+      expect(bitmap[0][0]).to eq(:purple)
+    end
+
+    it 'decodes single green pixel at odd position' do
+      # Isolated pixel at position 1 (odd) with high bit 0
+      ram[0x2000] = 0x02  # bit 1 set
+      bitmap = renderer.decode_hires_colors(ram, 0x2000)
+
+      expect(bitmap[0][1]).to eq(:green)
+    end
+
+    it 'decodes blue/orange with high bit set' do
+      # High bit set (palette 1)
+      ram[0x2000] = 0x81  # bit 0 set + high bit
+      bitmap = renderer.decode_hires_colors(ram, 0x2000)
+
+      expect(bitmap[0][0]).to eq(:blue)
+    end
+  end
+
+  describe '#render' do
+    it 'produces output with ANSI color codes' do
+      output = renderer.render(ram, base_addr: 0x2000, chars_wide: 40)
+      expect(output).to include("\e[")  # ANSI escape codes
+    end
+
+    it 'produces correct number of lines' do
+      output = renderer.render(ram, base_addr: 0x2000, chars_wide: 40)
+      lines = output.split("\n")
+      expect(lines.length).to eq(96)  # 192 / 2 = 96 half-block rows
+    end
+  end
+
+  describe '#render_lines' do
+    it 'returns array of lines' do
+      lines = renderer.render_lines(ram, base_addr: 0x2000, chars_wide: 40)
+      expect(lines).to be_an(Array)
+      expect(lines.length).to eq(96)
+    end
+  end
+
+  describe '#color_char' do
+    it 'returns space for black/black' do
+      expect(renderer.color_char(:black, :black)).to eq(" ")
+    end
+
+    it 'returns full block for same non-black colors' do
+      result = renderer.color_char(:green, :green)
+      expect(result).to include("\u2588")  # Full block
+      expect(result).to include("\e[38;2;")  # Foreground color
+    end
+
+    it 'returns lower half block for black/color' do
+      result = renderer.color_char(:black, :green)
+      expect(result).to include("\u2584")  # Lower half block
+    end
+
+    it 'returns upper half block for color/black' do
+      result = renderer.color_char(:green, :black)
+      expect(result).to include("\u2580")  # Upper half block
+    end
+
+    it 'returns upper half with fg/bg for different colors' do
+      result = renderer.color_char(:green, :purple)
+      expect(result).to include("\u2580")  # Upper half block
+      expect(result).to include("\e[38;2;")  # Foreground color
+      expect(result).to include("\e[48;2;")  # Background color
+    end
+  end
+
+  describe 'COLORS constant' do
+    it 'defines all 6 hires colors' do
+      expect(described_class::COLORS.keys).to contain_exactly(
+        :black, :white, :green, :purple, :orange, :blue
+      )
+    end
+
+    it 'has RGB arrays with 3 values each' do
+      described_class::COLORS.each do |name, rgb|
+        expect(rgb.length).to eq(3), "#{name} should have 3 RGB values"
+        rgb.each do |v|
+          expect(v).to be_between(0, 255), "#{name} RGB values should be 0-255"
+        end
+      end
+    end
+  end
+
+  describe '.render class method' do
+    it 'renders using a new instance' do
+      output = described_class.render(ram, base_addr: 0x2000, chars_wide: 40)
+      expect(output).to be_a(String)
+      expect(output.length).to be > 0
+    end
+  end
+end

--- a/spec/examples/apple2/text_renderer_spec.rb
+++ b/spec/examples/apple2/text_renderer_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+$LOAD_PATH.unshift File.expand_path('../../../examples/apple2/utilities', __dir__)
+require 'text_renderer'
+
+RSpec.describe RHDL::Apple2::TextRenderer do
+  let(:renderer) { described_class.new }
+
+  # Create a test screen array (24 rows x 40 cols)
+  let(:blank_screen) do
+    Array.new(24) { Array.new(40, 0xA0) }  # 0xA0 = space with high bit set
+  end
+
+  let(:hello_screen) do
+    screen = Array.new(24) { Array.new(40, 0xA0) }
+    "HELLO".each_char.with_index do |char, i|
+      screen[0][i] = char.ord | 0x80
+    end
+    screen
+  end
+
+  describe '#render' do
+    it 'produces output with borders' do
+      output = renderer.render(blank_screen)
+      expect(output).to include("+")
+      expect(output).to include("-")
+      expect(output).to include("|")
+    end
+
+    it 'has correct border width' do
+      output = renderer.render(blank_screen)
+      lines = output.split("\n")
+      # Top border should be 42 chars: + + 40 dashes + +
+      expect(lines.first).to eq("+" + ("-" * 40) + "+")
+    end
+
+    it 'renders character content' do
+      output = renderer.render(hello_screen)
+      expect(output).to include("HELLO")
+    end
+
+    it 'converts high-bit ASCII to normal ASCII' do
+      # Character code 0xC1 (A with high bit) should render as 'A'
+      screen = Array.new(24) { Array.new(40, 0xA0) }
+      screen[0][0] = 0xC1  # 'A' with high bit
+      output = renderer.render(screen)
+      expect(output).to include("|A")
+    end
+
+    it 'converts control characters to spaces' do
+      screen = Array.new(24) { Array.new(40, 0xA0) }
+      screen[0][0] = 0x00  # Control character
+      output = renderer.render(screen)
+      # Should be space, not control character
+      lines = output.split("\n")
+      expect(lines[1][1]).to eq(" ")
+    end
+  end
+
+  describe '#render_lines' do
+    it 'returns array of lines' do
+      lines = renderer.render_lines(blank_screen)
+      expect(lines).to be_an(Array)
+    end
+
+    it 'returns correct number of lines' do
+      lines = renderer.render_lines(blank_screen)
+      # 1 top border + 24 content + 1 bottom border = 26 lines
+      expect(lines.length).to eq(26)
+    end
+
+    it 'lines do not contain newlines' do
+      lines = renderer.render_lines(blank_screen)
+      lines.each do |line|
+        expect(line).not_to include("\n")
+      end
+    end
+  end
+
+  describe 'green screen mode' do
+    let(:green_renderer) { described_class.new(green: true) }
+
+    it 'includes ANSI green foreground code' do
+      output = green_renderer.render(blank_screen)
+      expect(output).to include("\e[32m")
+    end
+
+    it 'includes ANSI black background code' do
+      output = green_renderer.render(blank_screen)
+      expect(output).to include("\e[40m")
+    end
+
+    it 'includes ANSI reset code' do
+      output = green_renderer.render(blank_screen)
+      expect(output).to include("\e[0m")
+    end
+  end
+
+  describe 'constants' do
+    it 'defines correct screen dimensions' do
+      expect(described_class::SCREEN_ROWS).to eq(24)
+      expect(described_class::SCREEN_COLS).to eq(40)
+    end
+  end
+end


### PR DESCRIPTION
- Extract text, braille, and color renderers to separate utility modules
- Implement 3-bit sliding window algorithm for NTSC artifact colors
- Support 6 hires colors: black, white, green, purple, orange, blue
- Add --color option to apple2 binary (implies --hires)
- Add C key toggle for color mode in command mode
- Default width is 140 for color mode (half-blocks), 80 for braille
- Enable color mode by default for --karateka option
- Add comprehensive tests for all three renderers (60 tests)