### PR TITLE
Fix CPU register signal names for HDL mode emulation

### DIFF
--- a/examples/apple2/hdl/apple2.rb
+++ b/examples/apple2/hdl/apple2.rb
@@ -92,6 +92,8 @@ module RHDL
       output :a_debug, width: 8          # A register
       output :x_debug, width: 8          # X register
       output :y_debug, width: 8          # Y register
+      output :s_debug, width: 8          # Stack pointer
+      output :p_debug, width: 8          # Processor status
 
       # Pause control
       input :pause                       # Pause CPU execution
@@ -236,6 +238,8 @@ module RHDL
       port [:cpu, :debug_a] => :a_debug
       port [:cpu, :debug_x] => :x_debug
       port [:cpu, :debug_y] => :y_debug
+      port [:cpu, :debug_s] => :s_debug
+      port [:cpu, :debug_p] => :p_debug
 
       # Connect Disk II controller (slot 6)
       port :clk_14m => [:disk, :clk_14m]

--- a/examples/apple2/hdl/cpu6502.rb
+++ b/examples/apple2/hdl/cpu6502.rb
@@ -39,6 +39,7 @@ module RHDL
       output :debug_x, width: 8
       output :debug_y, width: 8
       output :debug_s, width: 8
+      output :debug_p, width: 8
       output :debug_second_byte
       output :debug_cycle2
       output :debug_addr_c2, width: 16
@@ -992,6 +993,7 @@ module RHDL
 
         # Status register pack for PHP
         status_reg = cat(flag_n, flag_v, lit(1, width: 1), ~irq_active, flag_d, flag_i, flag_z, flag_c)
+        debug_p <= status_reg
 
         rmw_out = mux(alu_mode1 == lit(ALU1_INP, width: 4), rmw_in,
           mux(alu_mode1 == lit(ALU1_P, width: 4), status_reg,

--- a/examples/mos6502/utilities/ir_simulator_runner.rb
+++ b/examples/mos6502/utilities/ir_simulator_runner.rb
@@ -144,8 +144,8 @@ class IRSimulatorRunner
       a: @sim.peek('cpu__a_reg'),
       x: @sim.peek('cpu__x_reg'),
       y: @sim.peek('cpu__y_reg'),
-      sp: @sim.peek('cpu__sp_reg'),
-      p: @sim.peek('cpu__p_reg'),
+      sp: @sim.peek('cpu__s_reg'),
+      p: @sim.peek('cpu__debug_p'),
       cycles: @cycles,
       halted: @halted,
       simulator_type: simulator_type


### PR DESCRIPTION
- Add debug_p output to CPU6502 for processor status register
- Add s_debug and p_debug outputs to Apple2 component
- Fix ir_simulator_runner.rb signal names:
  - cpu__sp_reg -> cpu__s_reg (stack pointer)
  - cpu__p_reg -> cpu__debug_p (processor status)

The HDL mode emulator was failing with "Unknown signal: cpu__sp_reg" because the IR simulator was using incorrect signal names that didn't match the flattened IR output from the Apple2/CPU6502 components.

https://claude.ai/code/session_01Lqcu4shjY1JpxXKZHgY3ve