### PR TITLE
Fix IrRunner color rendering to read from Rust backend

### DIFF
--- a/examples/apple2/utilities/apple2_ir.rb
+++ b/examples/apple2/utilities/apple2_ir.rb
@@ -472,6 +472,28 @@ module RHDL
       # Render hi-res screen with NTSC artifact colors
       # chars_wide: target width in characters (default 140)
       def render_hires_color(chars_wide: 140)
+        if @use_batched
+          render_hires_color_batched(chars_wide)
+        else
+          render_hires_color_fallback(chars_wide)
+        end
+      end
+
+      def render_hires_color_batched(chars_wide)
+        # Build a RAM array with hi-res page data from Rust backend
+        # ColorRenderer needs the full address space since it uses hires_line_address()
+        hires_ram = Array.new(HIRES_PAGE1_END + 1, 0)
+
+        # Read hi-res page data from Rust backend
+        # The hi-res page is 8KB at $2000-$3FFF
+        hires_data = @sim.read_ram(HIRES_PAGE1_START, HIRES_PAGE1_END - HIRES_PAGE1_START + 1).to_a
+        hires_data.each_with_index { |b, i| hires_ram[HIRES_PAGE1_START + i] = b }
+
+        renderer = ColorRenderer.new(chars_wide: chars_wide)
+        renderer.render(hires_ram, base_addr: HIRES_PAGE1_START)
+      end
+
+      def render_hires_color_fallback(chars_wide)
         @ram ||= Array.new(48 * 1024, 0)
         renderer = ColorRenderer.new(chars_wide: chars_wide)
         renderer.render(@ram, base_addr: HIRES_PAGE1_START)


### PR DESCRIPTION
The IrRunner#render_hires_color method was always using the Ruby @ram array which remains empty when batched execution is used (native Rust backend). This caused color mode to display nothing in the terminal.

Changes:
- Add render_hires_color_batched method that reads hi-res memory from Rust backend via @sim.read_ram() before passing to ColorRenderer
- Add render_hires_color_fallback for non-batched execution
- Add comprehensive tests for braille and color rendering modes with Karateka graphics to verify non-empty output

https://claude.ai/code/session_01XsayGrfhsXDfFmvTMDHrBe