### PR TITLE
Fix 6502 stack pointer reset value from 0xFF to 0xFD

### DIFF
--- a/examples/apple2/hdl/cpu6502.rb
+++ b/examples/apple2/hdl/cpu6502.rb
@@ -599,7 +599,7 @@ module RHDL
         a_reg: 0,
         x_reg: 0,
         y_reg: 0,
-        s_reg: 0xFF,
+        s_reg: 0xFD,  # 6502 reset decrements SP 3 times (dummy pushes)
         flag_c: 0,
         flag_z: 0,
         flag_i: 1,


### PR DESCRIPTION
The 6502 reset sequence performs 3 dummy stack pushes (for PCH, PCL, and status register), which decrements SP 3 times. Starting from $00, this results in SP=$FD after reset.

This fix resolves an issue where the IR compiler would crash to zero page after ~4.3M cycles due to stack pointer wraparound during RTS instructions. The ISA simulator already used SP=$FD after reset, causing a 2-byte offset that eventually led to reading garbage return addresses from the stack.

https://claude.ai/code/session_01XsayGrfhsXDfFmvTMDHrBe