### PR TITLE
Fix color mode height calculation for debug pane positioning

### DIFF
--- a/examples/apple2/bin/apple2
+++ b/examples/apple2/bin/apple2
@@ -131,7 +131,8 @@ class Apple2HDLTerminal
     @hires_width = [preferred, @term_cols].min
 
     # Calculate padding for hires display
-    hires_content_height = HIRES_HEIGHT  # Always 48 braille chars tall
+    # Color mode uses half-blocks (2 pixels/char = 96 lines), braille uses 4 pixels/char (48 lines)
+    hires_content_height = @color_mode ? 96 : HIRES_HEIGHT
     debug_panel_height = @debug ? 8 : 1  # 6 lines debug box + 2 gap, or 1 line for disk status
     total_content_height = hires_content_height + debug_panel_height
 


### PR DESCRIPTION
Color mode uses half-block characters (2 pixels per char = 96 lines) while braille mode uses 4 pixels per char (48 lines). The debug pane was positioned off-screen because HIRES_HEIGHT=48 was used for both.

https://claude.ai/code/session_01Ey6AXnB93wp6y9cPpjXcMB