### PR TITLE
Fix BitSelect#to_ir to handle dynamic bit indices

### DIFF
--- a/lib/rhdl/synth/bit_select.rb
+++ b/lib/rhdl/synth/bit_select.rb
@@ -3,6 +3,8 @@
 module RHDL
   module Synth
     # Synthesis bit select
+    # Handles both constant indices (becomes static slice) and
+    # dynamic indices (becomes shift-and-mask operation)
     class BitSelect < Expr
       attr_reader :base, :index
 
@@ -13,7 +15,31 @@ module RHDL
       end
 
       def to_ir
-        RHDL::Codegen::IR::Slice.new(base: @base.to_ir, range: @index..@index, width: 1)
+        if @index.is_a?(Integer)
+          # Constant index - static bit slice
+          RHDL::Codegen::IR::Slice.new(base: @base.to_ir, range: @index..@index, width: 1)
+        else
+          # Dynamic index - generate (base >> index) & 1
+          # This implements runtime bit selection
+          base_ir = @base.to_ir
+          index_ir = @index.to_ir
+
+          # (base >> index) & 1
+          shifted = RHDL::Codegen::IR::BinaryOp.new(
+            op: :>>,
+            left: base_ir,
+            right: index_ir,
+            width: base_ir.width
+          )
+
+          # Mask to get just the lowest bit
+          RHDL::Codegen::IR::BinaryOp.new(
+            op: :&,
+            left: shifted,
+            right: RHDL::Codegen::IR::Literal.new(value: 1, width: 1),
+            width: 1
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
The BitSelect synthesis class was always generating static Slice IR for
bit selection, even when the index was a dynamic expression (not an
integer). This caused incorrect behavior when the index was computed at
runtime, like `gameport[cpu_addr[2..0]]` in the Apple II gameport logic.

The fix checks if the index is an Integer:
- Constant index: generates a static Slice (existing behavior)
- Dynamic index: generates (base >> index) & 1 using shift-and-mask

This fixes the Apple II Karateka divergence where the IR compiler was
not outputting correct graphics because gameport button reads returned
incorrect values.

https://claude.ai/code/session_01TM9a6mDHY1gXw1p21jQd4u