### PR TITLE
Fix ALU INC/DEC width causing Z flag miscalculation

### DIFF
--- a/examples/apple2/hdl/cpu6502.rb
+++ b/examples/apple2/hdl/cpu6502.rb
@@ -997,8 +997,8 @@ module RHDL
 
         rmw_out = mux(alu_mode1 == lit(ALU1_INP, width: 4), rmw_in,
           mux(alu_mode1 == lit(ALU1_P, width: 4), status_reg,
-            mux(alu_mode1 == lit(ALU1_INC, width: 4), rmw_in + lit(1, width: 8),
-              mux(alu_mode1 == lit(ALU1_DEC, width: 4), rmw_in - lit(1, width: 8),
+            mux(alu_mode1 == lit(ALU1_INC, width: 4), (rmw_in + lit(1, width: 8))[7..0],
+              mux(alu_mode1 == lit(ALU1_DEC, width: 4), (rmw_in - lit(1, width: 8))[7..0],
                 mux(alu_mode1 == lit(ALU1_FLG, width: 4), rmw_in,
                   mux(alu_mode1 == lit(ALU1_BIT, width: 4), rmw_in,
                     mux(alu_mode1 == lit(ALU1_LSR, width: 4), cat(lit(0, width: 1), rmw_in[7..1]),


### PR DESCRIPTION
The synth `+` operator adds 1 bit for carry, making `rmw_in + lit(1, width: 8)` produce a 9-bit result instead of 8 bits. Since mux takes the max width of its branches, the entire rmw_out chain became 9 bits, which propagated to arith_out.

When comparing `arith_out == lit(0, width: 8)`, the literal was resized to 9 bits to match. This caused the Z flag to never be set when incrementing from 0xFF to 0x00, because the 9-bit result was 0x100 not 0x000.

The fix slices the INC/DEC results to 8 bits to maintain proper width:
- `(rmw_in + lit(1, width: 8))[7..0]` for INC
- `(rmw_in - lit(1, width: 8))[7..0]` for DEC

This fixes the Karateka $191x stuck loop where INY from 0xFF to 0x00 was not setting Z=1, causing BNE to always branch and creating an infinite loop.

https://claude.ai/code/session_01TM9a6mDHY1gXw1p21jQd4u