### PR TITLE
Add PS/2 keyboard support to Apple II emulator

### DIFF
--- a/examples/apple2/hdl/apple2.rb
+++ b/examples/apple2/hdl/apple2.rb
@@ -63,9 +63,13 @@ module RHDL
       output :hbl                        # Horizontal blanking
       output :vbl                        # Vertical blanking
 
-      # Keyboard interface
-      input :k, width: 8                 # Keyboard data
+      # Keyboard interface (directly from Keyboard HDL via PS/2)
+      input :ps2_clk                     # PS/2 clock input
+      input :ps2_data                    # PS/2 data input
       output :read_key                   # Keyboard read strobe
+
+      # Internal keyboard data wire (from Keyboard component)
+      wire :k, width: 8
 
       # Audio output
       output :speaker                    # 1-bit speaker output
@@ -108,6 +112,7 @@ module RHDL
       instance :speaker_toggle, SpeakerToggle
       instance :cpu, CPU6502
       instance :disk, DiskII
+      instance :keyboard, Keyboard
 
       # Internal wires for clocks
       wire :clk_7m
@@ -251,6 +256,14 @@ module RHDL
       port :cpu_addr => [:disk, :a]
       port :cpu_dout => [:disk, :d_in]
       port [:disk, :d_out] => :disk_dout
+
+      # Connect Keyboard controller (PS/2 to ASCII)
+      port :clk_14m => [:keyboard, :clk_14m]
+      port :reset => [:keyboard, :reset]
+      port :ps2_clk => [:keyboard, :ps2_clk]
+      port :ps2_data => [:keyboard, :ps2_data]
+      port :read_key => [:keyboard, :read]
+      port [:keyboard, :k] => :k
 
       # Soft switches state
       sequential clock: :q3, reset: :reset, reset_values: {

--- a/examples/apple2/utilities/ps2_encoder.rb
+++ b/examples/apple2/utilities/ps2_encoder.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+# PS/2 Protocol Encoder
+# Converts ASCII key codes to PS/2 scancodes and bit-bangs the PS/2 protocol
+
+module RHDL
+  module Apple2
+    # PS/2 keyboard encoder - converts ASCII to PS/2 scancodes
+    # and handles the PS/2 protocol bit-banging
+    class PS2Encoder
+      # PS/2 special codes
+      KEY_UP_CODE = 0xF0
+
+      # Build reverse lookup table: ASCII -> [scancode, needs_shift]
+      # Based on the scancode mappings in keyboard.rb
+      ASCII_TO_SCANCODE = {
+        # Letters (A-Z) - all unshifted in Apple II (uppercase only)
+        0x41 => [0x1C, false], # A
+        0x42 => [0x32, false], # B
+        0x43 => [0x21, false], # C
+        0x44 => [0x23, false], # D
+        0x45 => [0x24, false], # E
+        0x46 => [0x2B, false], # F
+        0x47 => [0x34, false], # G
+        0x48 => [0x33, false], # H
+        0x49 => [0x43, false], # I
+        0x4A => [0x3B, false], # J
+        0x4B => [0x42, false], # K
+        0x4C => [0x4B, false], # L
+        0x4D => [0x3A, false], # M
+        0x4E => [0x31, false], # N
+        0x4F => [0x44, false], # O
+        0x50 => [0x4D, false], # P
+        0x51 => [0x15, false], # Q
+        0x52 => [0x2D, false], # R
+        0x53 => [0x1B, false], # S
+        0x54 => [0x2C, false], # T
+        0x55 => [0x3C, false], # U
+        0x56 => [0x2A, false], # V
+        0x57 => [0x1D, false], # W
+        0x58 => [0x22, false], # X
+        0x59 => [0x35, false], # Y
+        0x5A => [0x1A, false], # Z
+
+        # Numbers (unshifted)
+        0x30 => [0x45, false], # 0
+        0x31 => [0x16, false], # 1
+        0x32 => [0x1E, false], # 2
+        0x33 => [0x26, false], # 3
+        0x34 => [0x25, false], # 4
+        0x35 => [0x2E, false], # 5
+        0x36 => [0x36, false], # 6
+        0x37 => [0x3D, false], # 7
+        0x38 => [0x3E, false], # 8
+        0x39 => [0x46, false], # 9
+
+        # Shifted numbers (symbols)
+        0x29 => [0x45, true],  # )
+        0x21 => [0x16, true],  # !
+        0x40 => [0x1E, true],  # @
+        0x23 => [0x26, true],  # #
+        0x24 => [0x25, true],  # $
+        0x25 => [0x2E, true],  # %
+        0x5E => [0x36, true],  # ^
+        0x26 => [0x3D, true],  # &
+        0x2A => [0x3E, true],  # *
+        0x28 => [0x46, true],  # (
+
+        # Special keys
+        0x20 => [0x29, false], # Space
+        0x0D => [0x5A, false], # Enter/Return
+        0x08 => [0x66, false], # Backspace
+        0x09 => [0x0D, false], # Tab
+        0x1B => [0x76, false], # Escape
+        0x7F => [0x71, false], # Delete
+
+        # Arrow keys (Apple II control codes)
+        0x15 => [0x74, false], # Right arrow (Ctrl-U)
+        # 0x08 already mapped to backspace, but Left uses same
+        0x0B => [0x75, false], # Up arrow (Ctrl-K)
+        0x0A => [0x72, false], # Down arrow (LF/Ctrl-J)
+      }.freeze
+
+      # Left shift scancode for shifted keys
+      LEFT_SHIFT_SCANCODE = 0x12
+
+      def initialize
+        @ps2_queue = []  # Queue of [clk, data] pairs to send
+        @current_bit = 0
+        @sending = false
+      end
+
+      # Queue a key press (and optionally release) for PS/2 transmission
+      # @param ascii [Integer] ASCII code of the key
+      # @param release [Boolean] Whether to also queue a key release after
+      def queue_key(ascii, release: true)
+        mapping = ASCII_TO_SCANCODE[ascii]
+        return unless mapping
+
+        scancode, needs_shift = mapping
+
+        # Send shift press if needed
+        queue_scancode(LEFT_SHIFT_SCANCODE) if needs_shift
+
+        # Send the key scancode
+        queue_scancode(scancode)
+
+        if release
+          # Send key release (F0 + scancode)
+          queue_key_release(scancode)
+
+          # Send shift release if needed
+          queue_key_release(LEFT_SHIFT_SCANCODE) if needs_shift
+        end
+      end
+
+      # Queue just a key release
+      def queue_key_release(scancode)
+        queue_scancode(KEY_UP_CODE)
+        queue_scancode(scancode)
+      end
+
+      # Queue a scancode for PS/2 transmission
+      # PS/2 protocol: 11 bits - 1 start (0) + 8 data (LSB first) + 1 parity (odd) + 1 stop (1)
+      # Data is sampled on falling edge of clock
+      def queue_scancode(scancode)
+        # Calculate odd parity (total 1-bits including parity should be odd)
+        parity = 1  # Start with 1 for odd parity
+        8.times { |i| parity ^= (scancode >> i) & 1 }
+
+        # Build the 11-bit frame
+        frame = []
+        frame << 0  # Start bit
+        8.times { |i| frame << ((scancode >> i) & 1) }  # Data bits (LSB first)
+        frame << parity  # Parity bit
+        frame << 1  # Stop bit
+
+        # Convert to clock/data pairs
+        # PS/2 clock is normally high, data changes when clock is high,
+        # then clock goes low (falling edge = sample point), then clock goes high
+        frame.each do |bit|
+          # Data setup: clock high, set data
+          @ps2_queue << [1, bit]
+          # Falling edge: clock low (receiver samples here)
+          @ps2_queue << [0, bit]
+          # Clock returns high
+          @ps2_queue << [1, bit]
+        end
+
+        # Inter-byte gap (clock high, data high)
+        10.times { @ps2_queue << [1, 1] }
+      end
+
+      # Get the next PS/2 clock/data pair to send
+      # @return [Array<Integer>] [clk, data] or [1, 1] if idle
+      def next_ps2_state
+        if @ps2_queue.empty?
+          [1, 1]  # Idle state: clock and data both high
+        else
+          @ps2_queue.shift
+        end
+      end
+
+      # Check if there's data queued to send
+      def sending?
+        !@ps2_queue.empty?
+      end
+
+      # Clear the queue
+      def clear
+        @ps2_queue.clear
+      end
+
+      # Get queue length (for debugging)
+      def queue_length
+        @ps2_queue.length
+      end
+    end
+  end
+end

--- a/spec/examples/apple2/ps2_encoder_spec.rb
+++ b/spec/examples/apple2/ps2_encoder_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Load the PS2 encoder
+require_relative '../../../examples/apple2/utilities/ps2_encoder'
+
+RSpec.describe RHDL::Apple2::PS2Encoder do
+  let(:encoder) { described_class.new }
+
+  describe '#initialize' do
+    it 'starts in idle state' do
+      expect(encoder.sending?).to be false
+    end
+
+    it 'returns idle PS/2 signals (both high)' do
+      clk, data = encoder.next_ps2_state
+      expect(clk).to eq(1)
+      expect(data).to eq(1)
+    end
+  end
+
+  describe '#queue_key' do
+    it 'queues a key for transmission' do
+      encoder.queue_key(0x41) # 'A'
+      expect(encoder.sending?).to be true
+    end
+
+    it 'returns non-idle PS/2 signals while sending' do
+      encoder.queue_key(0x41) # 'A'
+      # Get a few states to ensure we're transmitting
+      states = 5.times.map { encoder.next_ps2_state }
+      # Should have some clock transitions (not all high)
+      clocks = states.map(&:first)
+      expect(clocks.uniq.length).to be > 1
+    end
+
+    it 'eventually returns to idle after transmission' do
+      encoder.queue_key(0x41) # 'A'
+      # Drain the queue (should take roughly 33 states per scancode * 2 for press+release)
+      500.times { encoder.next_ps2_state }
+      expect(encoder.sending?).to be false
+    end
+
+    context 'with shifted keys' do
+      it 'queues shift press, key, key release, shift release for symbols' do
+        encoder.queue_key(0x21) # '!' (shifted '1')
+        # Should be sending shift + 1 + releases
+        expect(encoder.sending?).to be true
+        # The queue should be longer than for an unshifted key
+        expect(encoder.queue_length).to be > 100
+      end
+    end
+  end
+
+  describe '#queue_scancode' do
+    it 'queues an 11-bit PS/2 frame' do
+      encoder.queue_scancode(0x1C) # Scancode for 'A'
+      # 11 bits * 3 states per bit + gap = ~43 states
+      expect(encoder.queue_length).to be >= 33
+    end
+
+    it 'generates correct parity' do
+      encoder.queue_scancode(0x00) # All zeros (parity should be 1)
+      # Extract the parity bit from the frame
+      # This is a basic structural test - we verify the queue is populated
+      expect(encoder.sending?).to be true
+    end
+  end
+
+  describe '#clear' do
+    it 'clears the queue' do
+      encoder.queue_key(0x41)
+      expect(encoder.sending?).to be true
+      encoder.clear
+      expect(encoder.sending?).to be false
+    end
+  end
+
+  describe 'ASCII to scancode mapping' do
+    # Test a few key mappings
+    [
+      [0x41, 0x1C, false], # A
+      [0x5A, 0x1A, false], # Z
+      [0x30, 0x45, false], # 0
+      [0x39, 0x46, false], # 9
+      [0x20, 0x29, false], # Space
+      [0x0D, 0x5A, false], # Enter
+      [0x08, 0x66, false], # Backspace
+      [0x21, 0x16, true],  # ! (shifted 1)
+      [0x40, 0x1E, true],  # @ (shifted 2)
+    ].each do |ascii, expected_scancode, needs_shift|
+      it "maps ASCII #{ascii.to_s(16)} correctly" do
+        mapping = RHDL::Apple2::PS2Encoder::ASCII_TO_SCANCODE[ascii]
+        expect(mapping).not_to be_nil, "Missing mapping for ASCII #{ascii.to_s(16)}"
+        scancode, shift = mapping
+        expect(scancode).to eq(expected_scancode)
+        expect(shift).to eq(needs_shift)
+      end
+    end
+  end
+
+  describe 'PS/2 protocol timing' do
+    it 'generates proper clock transitions for each bit' do
+      encoder.queue_scancode(0xAA) # Some test scancode
+
+      # Each bit should have: [1, data], [0, data], [1, data]
+      # Verify we get clock high->low->high transitions
+      clock_states = []
+      while encoder.sending?
+        clk, _data = encoder.next_ps2_state
+        clock_states << clk
+      end
+
+      # Should have alternating clock states (high-low-high for each bit)
+      # 11 bits * 3 states = 33 states minimum
+      expect(clock_states.length).to be >= 33
+    end
+
+    it 'data is stable on falling clock edge' do
+      encoder.queue_scancode(0x1C) # Scancode for 'A'
+
+      prev_clk = 1
+      prev_data = 1
+      data_on_falling_edges = []
+
+      while encoder.sending?
+        clk, data = encoder.next_ps2_state
+        # Capture data on falling edge
+        if prev_clk == 1 && clk == 0
+          data_on_falling_edges << data
+        end
+        prev_clk = clk
+        prev_data = data
+      end
+
+      # Should have 11 bits captured (start + 8 data + parity + stop)
+      expect(data_on_falling_edges.length).to eq(11)
+
+      # Verify start bit is 0
+      expect(data_on_falling_edges[0]).to eq(0)
+
+      # Verify stop bit is 1
+      expect(data_on_falling_edges[10]).to eq(1)
+
+      # Verify data bits (LSB first) = 0x1C = 0b00011100
+      data_bits = data_on_falling_edges[1..8]
+      received_byte = data_bits.each_with_index.reduce(0) { |acc, (bit, i)| acc | (bit << i) }
+      expect(received_byte).to eq(0x1C)
+    end
+  end
+end


### PR DESCRIPTION
Integrates the PS/2 keyboard controller HDL component into the Apple II
system, replacing direct ASCII injection with proper PS/2 protocol.

Key changes:
- Modified Apple2 HDL to use ps2_clk and ps2_data inputs instead of
  direct k input, instantiating the Keyboard component internally
- Added PS2Encoder utility class that converts ASCII to PS/2 scancodes
  and implements the PS/2 bit-banging protocol (11-bit frames)
- Updated HdlRunner, IrRunner, and NetlistRunner to use PS2Encoder
  for keyboard input, driving ps2_clk and ps2_data signals each cycle
- Updated tests to use PS/2 protocol for keyboard verification

The PS2Encoder handles:
- ASCII to PS/2 scancode conversion (A-Z, 0-9, symbols, special keys)
- Shift key handling for shifted symbols
- Proper PS/2 frame format (start bit, 8 data bits LSB-first, odd parity, stop bit)
- Key press and release sequences

https://claude.ai/code/session_011VsvLYRrwKZabs9W1oTAan