### PR TITLE
Fix HDL IR runners to require native extensions (no fallback)

### DIFF
--- a/examples/apple2/utilities/ir_simulator_runner.rb
+++ b/examples/apple2/utilities/ir_simulator_runner.rb
@@ -64,6 +64,7 @@ module RHDL
         @sub_cycles = sub_cycles.clamp(1, 14)
 
         # Create the simulator based on backend choice
+        # All wrappers require native Rust extensions - will raise LoadError if unavailable
         @sim = case backend
                when :interpret
                  RHDL::Codegen::IR::IrInterpreterWrapper.new(@ir_json, allow_fallback: false, sub_cycles: @sub_cycles)
@@ -72,7 +73,7 @@ module RHDL
                  RHDL::Codegen::IR::IrJitWrapper.new(@ir_json, allow_fallback: false, sub_cycles: @sub_cycles)
                when :compile
                  require 'rhdl/codegen/ir/sim/ir_compiler'
-                 RHDL::Codegen::IR::IrCompilerWrapper.new(@ir_json, sub_cycles: @sub_cycles)
+                 RHDL::Codegen::IR::IrCompilerWrapper.new(@ir_json, allow_fallback: false, sub_cycles: @sub_cycles)
                else
                  raise ArgumentError, "Unknown backend: #{backend}. Use :interpret, :jit, or :compile"
                end

--- a/examples/mos6502/utilities/ir_simulator_runner.rb
+++ b/examples/mos6502/utilities/ir_simulator_runner.rb
@@ -26,14 +26,16 @@ class IRSimulatorRunner
   def create_simulator
     sim = case @sim_backend
     when :interpret
-      # IrInterpreterWrapper has built-in Ruby fallback if native extension unavailable
-      RHDL::Codegen::IR::IrInterpreterWrapper.new(@ir_json)
+      # Requires native Rust extension - will raise LoadError if unavailable
+      RHDL::Codegen::IR::IrInterpreterWrapper.new(@ir_json, allow_fallback: false)
     when :jit
-      raise "IR JIT not available" unless RHDL::Codegen::IR::IR_JIT_AVAILABLE
-      RHDL::Codegen::IR::IrJitWrapper.new(@ir_json)
+      # Requires native Rust JIT extension - will raise LoadError if unavailable
+      require 'rhdl/codegen/ir/sim/ir_jit'
+      RHDL::Codegen::IR::IrJitWrapper.new(@ir_json, allow_fallback: false)
     when :compile
-      raise "IR Compiler not available" unless RHDL::Codegen::IR::IR_COMPILER_AVAILABLE
-      RHDL::Codegen::IR::IrCompilerWrapper.new(@ir_json)
+      # Requires native Rust compiler extension - will raise LoadError if unavailable
+      require 'rhdl/codegen/ir/sim/ir_compiler'
+      RHDL::Codegen::IR::IrCompilerWrapper.new(@ir_json, allow_fallback: false)
     else
       raise "Unknown IR backend: #{@sim_backend}"
     end


### PR DESCRIPTION
- Update ir_simulator_runner.rb (mos6502) to use allow_fallback: false
  for all IR wrappers, requiring native Rust extensions
- Update ir_simulator_runner.rb (apple2) to use allow_fallback: false
  for all IR wrappers, requiring native Rust extensions
- Add allow_fallback parameter support to IrCompilerWrapper
- Fix IrInterpreterWrapper methods to handle fallback mode safely
  (defensive code, though fallback is disabled)

Previously, HDL mode would fail with unclear error messages.
Now it raises LoadError with instructions to run 'rake native:build'.

https://claude.ai/code/session_011RNcutcTaEGcpMKZstjFQe