### PR TITLE
Add comprehensive examples documentation and update README

### DIFF
--- a/docs/gameboy.md
+++ b/docs/gameboy.md
@@ -1,0 +1,524 @@
+# Game Boy Emulation
+
+The `examples/gameboy/` directory contains a comprehensive Game Boy emulation system based on the MiSTer Gameboy_MiSTer reference implementation. It supports the original DMG (Dot Matrix Game), Game Boy Color (GBC), and Super Game Boy (SGB) modes.
+
+## Overview
+
+The Game Boy emulation consists of:
+
+- **HDL Components** (`examples/gameboy/hdl/`): Cycle-accurate hardware models
+- **SM83 CPU**: Z80 variant CPU core with full instruction set
+- **PPU**: Pixel Processing Unit with background, window, and sprite rendering
+- **APU**: Audio Processing Unit with 4 sound channels
+- **Memory Controllers**: MBC1, MBC2, MBC3, MBC5 mapper support
+- **Multiple Backends**: HDL, IR-level, and Verilator simulation
+
+## Quick Start
+
+### Running the Emulator
+
+```bash
+# Run with test ROM
+rhdl examples gameboy --rom cpu_instrs.gb
+
+# Run demo display
+rhdl examples gameboy --demo
+
+# Enable audio output
+rhdl examples gameboy --rom game.gb --audio
+```
+
+### Command Line Options
+
+```
+Usage: rhdl examples gameboy [options] [rom.gb]
+
+Options:
+  --rom FILE            Load ROM file
+  --demo                Run built-in demo display
+  --gbc                 Force Game Boy Color mode
+  --sgb                 Force Super Game Boy mode
+  --audio               Enable audio output
+  --debug               Show CPU state in status line
+  --sim BACKEND         Simulation backend: ruby, jit, compile
+  --dry-run             Initialize but don't run
+```
+
+## Architecture
+
+### System Block Diagram
+
+```
++-----------------------------------------------------------------------------+
+|                           Game Boy System                                    |
++-----------------------------------------------------------------------------+
+|                                                                             |
+|  +-----------+     +----------+     +---------------------------+           |
+|  |   SM83    |     |  Timer   |     |      PPU (Video)          |           |
+|  |   CPU     |<--->| Counter  |---->|  - Background layer       |           |
+|  | 4.19 MHz  |     +----------+     |  - Window layer           |           |
+|  +-----+-----+                      |  - 40 sprites (8x8/8x16)  |           |
+|        |                            |  - 160x144 LCD output     |           |
+|        v                            +---------------------------+           |
+|  +-----+------------------------------------------------+                   |
+|  |                     Address/Data Bus                 |                   |
+|  +--+--------+--------+--------+--------+--------+------+                   |
+|     |        |        |        |        |        |                          |
+|  +--+--+  +--+--+  +--+--+  +--+--+  +--+--+  +--+--+                       |
+|  | ROM |  | VRAM|  | WRAM|  | OAM |  | HRAM|  | I/O |                       |
+|  |0-8MB|  | 8KB |  | 8KB |  |160B |  |127B |  |Regs |                       |
+|  +-----+  +-----+  +-----+  +-----+  +-----+  +-----+                       |
+|                                                                             |
+|  +-----------+     +-----------+     +-----------+                          |
+|  |    APU    |     |   Link    |     |  Joypad   |                          |
+|  | 4 Channel |     |   Port    |     | 8 Buttons |                          |
+|  +-----------+     +-----------+     +-----------+                          |
+|                                                                             |
++-----------------------------------------------------------------------------+
+```
+
+### Memory Map
+
+| Address Range | Size | Description |
+|---------------|------|-------------|
+| $0000-$00FF | 256B | Boot ROM (when enabled) |
+| $0000-$3FFF | 16KB | ROM Bank 0 (fixed) |
+| $4000-$7FFF | 16KB | ROM Bank 1-N (switchable) |
+| $8000-$9FFF | 8KB | Video RAM (VRAM) |
+| $A000-$BFFF | 8KB | Cartridge RAM (if present) |
+| $C000-$CFFF | 4KB | Work RAM Bank 0 |
+| $D000-$DFFF | 4KB | Work RAM Bank 1-7 (GBC) |
+| $E000-$FDFF | | Echo RAM (mirrors $C000-$DDFF) |
+| $FE00-$FE9F | 160B | OAM (Object Attribute Memory) |
+| $FEA0-$FEFF | | Unusable |
+| $FF00-$FF7F | 128B | I/O Registers |
+| $FF80-$FFFE | 127B | High RAM (HRAM) |
+| $FFFF | 1B | Interrupt Enable Register |
+
+### Interrupt Vectors
+
+| Address | Description |
+|---------|-------------|
+| $0040 | V-Blank interrupt |
+| $0048 | LCD STAT interrupt |
+| $0050 | Timer interrupt |
+| $0058 | Serial interrupt |
+| $0060 | Joypad interrupt |
+
+## CPU: SM83
+
+The SM83 is a modified Z80 processor, sometimes called the "LR35902" or "Game Boy CPU".
+
+### Registers
+
+```
++---+---+   +---+---+   +---+---+   +---+---+
+| A | F |   | B | C |   | D | E |   | H | L |
++---+---+   +---+---+   +---+---+   +---+---+
+   AF          BC          DE          HL
+
++-------+   +-------+
+|  SP   |   |  PC   |
++-------+   +-------+
+  Stack     Program
+ Pointer    Counter
+```
+
+### Flags Register (F)
+
+| Bit | Name | Description |
+|-----|------|-------------|
+| 7 | Z | Zero flag |
+| 6 | N | Subtract flag |
+| 5 | H | Half-carry flag |
+| 4 | C | Carry flag |
+| 3-0 | - | Always 0 |
+
+### Instruction Set
+
+The SM83 supports 245 opcodes plus 256 CB-prefixed opcodes:
+
+| Category | Instructions |
+|----------|--------------|
+| Load | LD, LDH, PUSH, POP |
+| Arithmetic | ADD, ADC, SUB, SBC, INC, DEC, DAA, CPL |
+| Logic | AND, OR, XOR, CP |
+| Rotate/Shift | RLCA, RRCA, RLA, RRA, RLC, RRC, RL, RR, SLA, SRA, SRL, SWAP |
+| Bit | BIT, SET, RES |
+| Jump | JP, JR, CALL, RET, RETI, RST |
+| Misc | NOP, HALT, STOP, DI, EI, SCF, CCF |
+
+### Timing
+
+| Clock | Frequency | Description |
+|-------|-----------|-------------|
+| Main | 4.194304 MHz | Master clock (DMG) |
+| Main (GBC 2x) | 8.388608 MHz | Double-speed mode |
+| M-cycle | ~1.05 MHz | Machine cycle (4 T-states) |
+| Frame | ~59.7 Hz | Display refresh rate |
+
+## PPU (Pixel Processing Unit)
+
+### Video Modes
+
+| Mode | Duration | Description |
+|------|----------|-------------|
+| 0 | 204 cycles | H-Blank |
+| 1 | 4560 cycles | V-Blank (10 lines) |
+| 2 | 80 cycles | OAM Search |
+| 3 | 172 cycles | Drawing |
+
+### Display Specifications
+
+| Parameter | DMG | GBC |
+|-----------|-----|-----|
+| Resolution | 160x144 | 160x144 |
+| Colors | 4 shades | 32,768 colors |
+| BG Palettes | 1 | 8 |
+| Sprite Palettes | 2 | 8 |
+| Sprites | 40 total, 10/line | 40 total, 10/line |
+| Sprite Size | 8x8 or 8x16 | 8x8 or 8x16 |
+| Tile Size | 8x8 pixels | 8x8 pixels |
+| BG Map | 32x32 tiles | 32x32 tiles |
+
+### LCD Control Register ($FF40 - LCDC)
+
+| Bit | Name | Description |
+|-----|------|-------------|
+| 7 | LCD Enable | 0=Off, 1=On |
+| 6 | Window Tile Map | 0=$9800, 1=$9C00 |
+| 5 | Window Enable | 0=Off, 1=On |
+| 4 | BG/Window Tile Data | 0=$8800, 1=$8000 |
+| 3 | BG Tile Map | 0=$9800, 1=$9C00 |
+| 2 | Sprite Size | 0=8x8, 1=8x16 |
+| 1 | Sprite Enable | 0=Off, 1=On |
+| 0 | BG/Window Enable | 0=Off, 1=On (DMG) |
+
+## APU (Audio Processing Unit)
+
+The Game Boy APU produces sound through 4 channels:
+
+### Channel 1: Square Wave with Sweep
+
+```
++-------------+     +--------+     +--------+     +-----+
+| Sweep Unit  |---->| Square |---->| Volume |---->| Mix |
+| NR10        |     | Wave   |     | NR12   |     |     |
++-------------+     +--------+     +--------+     +-----+
+                    | Duty   |
+                    | NR11   |
+                    +--------+
+```
+
+### Channel 2: Square Wave
+
+```
++--------+     +--------+     +-----+
+| Square |---->| Volume |---->| Mix |
+| Wave   |     | NR22   |     |     |
+| NR21   |     +--------+     +-----+
++--------+
+```
+
+### Channel 3: Programmable Wave
+
+```
++--------+     +--------+     +-----+
+| Wave   |---->| Volume |---->| Mix |
+| RAM    |     | NR32   |     |     |
+| $FF30+ |     +--------+     +-----+
++--------+
+```
+
+### Channel 4: Noise
+
+```
++--------+     +--------+     +-----+
+| LFSR   |---->| Volume |---->| Mix |
+| NR43   |     | NR42   |     |     |
++--------+     +--------+     +-----+
+```
+
+### Audio Registers
+
+| Register | Address | Description |
+|----------|---------|-------------|
+| NR10 | $FF10 | Channel 1 sweep |
+| NR11 | $FF11 | Channel 1 duty/length |
+| NR12 | $FF12 | Channel 1 volume envelope |
+| NR13 | $FF13 | Channel 1 frequency low |
+| NR14 | $FF14 | Channel 1 frequency high/control |
+| NR21 | $FF16 | Channel 2 duty/length |
+| NR22 | $FF17 | Channel 2 volume envelope |
+| NR23 | $FF18 | Channel 2 frequency low |
+| NR24 | $FF19 | Channel 2 frequency high/control |
+| NR30 | $FF1A | Channel 3 enable |
+| NR31 | $FF1B | Channel 3 length |
+| NR32 | $FF1C | Channel 3 volume |
+| NR33 | $FF1D | Channel 3 frequency low |
+| NR34 | $FF1E | Channel 3 frequency high/control |
+| NR41 | $FF20 | Channel 4 length |
+| NR42 | $FF21 | Channel 4 volume envelope |
+| NR43 | $FF22 | Channel 4 polynomial counter |
+| NR44 | $FF23 | Channel 4 control |
+| NR50 | $FF24 | Master volume |
+| NR51 | $FF25 | Channel panning |
+| NR52 | $FF26 | Sound enable |
+
+## Memory Bank Controllers (MBC)
+
+The Game Boy uses memory bank controllers for cartridges larger than 32KB.
+
+### MBC1
+
+The most common early mapper supporting up to 2MB ROM and 32KB RAM.
+
+| Mode | ROM Banks | RAM Banks |
+|------|-----------|-----------|
+| Mode 0 | 128 (2MB) | 1 (8KB) |
+| Mode 1 | 32 (512KB) | 4 (32KB) |
+
+**Registers:**
+- $0000-$1FFF: RAM Enable (write $0A to enable)
+- $2000-$3FFF: ROM Bank (5 bits)
+- $4000-$5FFF: RAM Bank / Upper ROM bits
+- $6000-$7FFF: Mode Select
+
+### MBC2
+
+Simpler mapper with built-in 512x4-bit RAM.
+
+| Feature | Specification |
+|---------|---------------|
+| ROM | Up to 256KB (16 banks) |
+| RAM | 512x4 bits (built-in) |
+
+### MBC3
+
+Adds Real-Time Clock support.
+
+| Feature | Specification |
+|---------|---------------|
+| ROM | Up to 2MB (128 banks) |
+| RAM | Up to 32KB (4 banks) |
+| RTC | Seconds, Minutes, Hours, Days |
+
+### MBC5
+
+Most advanced standard mapper.
+
+| Feature | Specification |
+|---------|---------------|
+| ROM | Up to 8MB (512 banks) |
+| RAM | Up to 128KB (16 banks) |
+| Rumble | Optional motor support |
+
+## HDL Components
+
+### GB (`examples/gameboy/hdl/gb.rb`)
+
+Top-level Game Boy system integrating all components.
+
+**Key Inputs:**
+- `clk_sys` - System clock
+- `ce` - 4MHz clock enable
+- `ce_2x` - 8MHz clock enable (GBC double speed)
+- `reset` - System reset
+- `is_gbc` - Game Boy Color mode
+- `is_sgb` - Super Game Boy mode
+- `joystick` - Button input
+- `cart_do` - Cartridge data
+
+**Key Outputs:**
+- `lcd_data` - 15-bit LCD pixel data
+- `lcd_clkena` - LCD clock enable
+- `audio_l`, `audio_r` - 16-bit stereo audio
+
+### SM83 (`examples/gameboy/hdl/cpu/sm83.rb`)
+
+The SM83 CPU core with microcode-driven execution.
+
+**Features:**
+- Complete instruction set implementation
+- T-state and M-cycle accurate timing
+- Interrupt handling (IME, IE, IF)
+- HALT and STOP modes
+- Debug outputs for all registers
+
+### Video (`examples/gameboy/hdl/ppu/video.rb`)
+
+Pixel Processing Unit handling all display modes.
+
+**Features:**
+- Background and window layers
+- Sprite rendering with priority
+- Mode transitions (OAM, Draw, H-Blank, V-Blank)
+- DMA transfer support
+- GBC color palette support
+
+### Sound (`examples/gameboy/hdl/apu/sound.rb`)
+
+Master audio processor coordinating all channels.
+
+**Channels:**
+- `channel_square.rb` - Square wave (x2)
+- `channel_wave.rb` - Programmable wave
+- `channel_noise.rb` - Noise generator
+
+### Timer (`examples/gameboy/hdl/timer.rb`)
+
+Timer and divider counter.
+
+**Registers:**
+- DIV ($FF04) - Divider (increments at 16384 Hz)
+- TIMA ($FF05) - Timer counter
+- TMA ($FF06) - Timer modulo
+- TAC ($FF07) - Timer control
+
+### Mappers (`examples/gameboy/hdl/mappers/`)
+
+Memory bank controller implementations.
+
+- `mbc1.rb` - MBC1 mapper
+- `mbc2.rb` - MBC2 mapper
+- `mbc3.rb` - MBC3 mapper with RTC
+- `mbc5.rb` - MBC5 mapper with rumble
+
+## Simulation Backends
+
+### HDL Mode (Default)
+
+Cycle-accurate simulation using RHDL HDL components.
+
+```bash
+rhdl examples gameboy --sim ruby --rom game.gb
+```
+
+### IR Mode
+
+Gate-level intermediate representation simulation.
+
+```bash
+rhdl examples gameboy --sim jit --rom game.gb
+```
+
+### Verilator Mode
+
+High-performance Verilator-compiled simulation.
+
+```bash
+rhdl examples gameboy --sim verilator --rom game.gb
+```
+
+## Display Rendering
+
+### LCD Renderer
+
+The LCD renderer supports multiple output modes:
+
+**ASCII Mode:**
+```ruby
+renderer = LcdRenderer.new(chars_wide: 80)
+puts renderer.render_ascii(framebuffer)
+```
+
+**Braille Mode (High Resolution):**
+```ruby
+renderer = LcdRenderer.new(chars_wide: 80, invert: false)
+puts renderer.render_braille(framebuffer)
+```
+
+## Joypad Input
+
+| Button | Bit | Action |
+|--------|-----|--------|
+| Right | 0 | Direction |
+| Left | 1 | Direction |
+| Up | 2 | Direction |
+| Down | 3 | Direction |
+| A | 0 | Button |
+| B | 1 | Button |
+| Select | 2 | Button |
+| Start | 3 | Button |
+
+## File Structure
+
+```
+examples/gameboy/
++-- bin/
+|   +-- gb                      # Main emulator executable
++-- hdl/                        # HDL components
+|   +-- cpu/
+|   |   +-- sm83.rb             # SM83 CPU core
+|   |   +-- alu.rb              # ALU
+|   |   +-- registers.rb        # Register file
+|   |   +-- mcode.rb            # Microcode generator
+|   +-- ppu/
+|   |   +-- video.rb            # PPU controller
+|   |   +-- lcd.rb              # LCD timing
+|   |   +-- sprites.rb          # Sprite renderer
+|   +-- apu/
+|   |   +-- sound.rb            # Audio master
+|   |   +-- channel_square.rb   # Square wave channel
+|   |   +-- channel_wave.rb     # Wave channel
+|   |   +-- channel_noise.rb    # Noise channel
+|   +-- memory/
+|   |   +-- dpram.rb            # Dual-port RAM
+|   |   +-- spram.rb            # Single-port RAM
+|   +-- mappers/
+|   |   +-- mappers.rb          # Mapper switcher
+|   |   +-- mbc1.rb             # MBC1
+|   |   +-- mbc2.rb             # MBC2
+|   |   +-- mbc3.rb             # MBC3
+|   |   +-- mbc5.rb             # MBC5
+|   +-- dma/
+|   |   +-- hdma.rb             # DMA engines
+|   +-- gb.rb                   # Top-level GB core
+|   +-- timer.rb                # Timer/counter
+|   +-- link.rb                 # Serial link
+|   +-- speedcontrol.rb         # GBC speed control
++-- utilities/
+|   +-- gameboy_hdl.rb          # HDL runner
+|   +-- gameboy_ir.rb           # IR runner
+|   +-- gameboy_verilator.rb    # Verilator runner
+|   +-- lcd_renderer.rb         # Display rendering
+|   +-- speaker.rb              # Audio output
++-- software/
+|   +-- roms/                   # Test ROMs
++-- gameboy.rb                  # Main loader
++-- demo_display.rb             # Demo program
+```
+
+## Game Boy Color Features
+
+When running in GBC mode (`--gbc`):
+
+- **Double Speed Mode**: CPU can run at 8MHz
+- **Extra VRAM**: Second VRAM bank ($8000-$9FFF bank 1)
+- **Extra WRAM**: 7 additional work RAM banks
+- **Color Palettes**: 8 BG palettes, 8 sprite palettes (4 colors each)
+- **HDMA**: High-speed DMA for VRAM
+- **Infrared**: IR communication port
+
+## Super Game Boy Features
+
+When running in SGB mode (`--sgb`):
+
+- **Border**: Custom border graphics
+- **Palettes**: 4 customizable palettes
+- **Multiplayer**: Up to 4 controllers
+- **Sound Effects**: SNES audio mixing
+
+## References
+
+- [Pan Docs](https://gbdev.io/pandocs/) - Comprehensive Game Boy documentation
+- [Game Boy CPU Manual](http://marc.rawer.de/Gameboy/Docs/GBCPUman.pdf)
+- [MiSTer Gameboy_MiSTer](https://github.com/MiSTer-devel/Gameboy_MiSTer) - Reference implementation
+- [RGBDS Documentation](https://rgbds.gbdev.io/)
+
+## See Also
+
+- [MOS 6502 CPU](mos6502_cpu.md) - 6502 implementation
+- [Apple II Emulation](apple2.md) - Apple II system
+- [Simulation Backends](simulation.md) - Performance options
+- [DSL Reference](dsl.md) - RHDL DSL documentation

--- a/docs/riscv.md
+++ b/docs/riscv.md
@@ -1,0 +1,545 @@
+# RISC-V RV32I CPU Implementation
+
+The `examples/riscv/` directory contains RISC-V RV32I processor implementations demonstrating both single-cycle and pipelined CPU architectures. These examples showcase RHDL's capabilities for building modern 32-bit processors with full Verilog export support.
+
+## Overview
+
+The RISC-V implementation includes:
+
+- **Single-Cycle CPU**: Simple datapath executing one instruction per clock
+- **5-Stage Pipelined CPU**: IF-ID-EX-MEM-WB pipeline with hazard handling
+- **Full RV32I Base Set**: All 47 base integer instructions
+- **Assembler**: Two-pass assembler for RV32I programs
+- **Test Harnesses**: Clean testing interfaces
+
+## Quick Start
+
+### Running Tests
+
+```bash
+# Run all RISC-V tests
+bundle exec rspec spec/examples/riscv/
+
+# Run specific test
+bundle exec rspec spec/examples/riscv/cpu_spec.rb
+bundle exec rspec spec/examples/riscv/pipeline_spec.rb
+```
+
+### Using the CPU
+
+```ruby
+require_relative 'examples/riscv/hdl/harness'
+
+harness = RISCV::Harness.new
+harness.load_program([
+  0x00500093,  # addi x1, x0, 5
+  0x00A00113,  # addi x2, x0, 10
+  0x002081B3,  # add x3, x1, x2
+])
+harness.reset!
+harness.run_cycles(10)
+
+puts "x1 = #{harness.read_reg(1)}"  # => 5
+puts "x2 = #{harness.read_reg(2)}"  # => 10
+puts "x3 = #{harness.read_reg(3)}"  # => 15
+```
+
+## Architecture: Single-Cycle CPU
+
+### Block Diagram
+
+```
++-----------------------------------------------------------------------------+
+|                      RV32I Single-Cycle Datapath                             |
++-----------------------------------------------------------------------------+
+|                                                                             |
+|  +--------+     +--------+     +----------+     +--------+                  |
+|  |   PC   |---->| Inst   |---->| Decoder  |---->|Control |                  |
+|  |Register|     | Memory |     |          |     |Signals |                  |
+|  +---+----+     +--------+     +----------+     +---+----+                  |
+|      |              |                               |                        |
+|      |              v                               |                        |
+|      |         +--------+                           |                        |
+|      |         | ImmGen |                           |                        |
+|      |         +---+----+                           |                        |
+|      |             |                                |                        |
+|  +---+-------------+--------------------------------+----+                   |
+|  |                     Datapath Muxes                    |                   |
+|  +---+-----------+-------------------+-------------------+                   |
+|      |           |                   |                                       |
+|      v           v                   v                                       |
+|  +-------+   +-------+           +-------+     +--------+                   |
+|  |  PC   |   | Reg   |  rs1/rs2  |  ALU  |---->|  Data  |                   |
+|  | +4/Br |   | File  |---------->|       |     | Memory |                   |
+|  +-------+   | 32x32 |           +-------+     +--------+                   |
+|              +-------+               |              |                        |
+|                  ^                   v              v                        |
+|                  |           +------+------+       |                        |
+|                  +-----------| Write Back |<------+                        |
+|                              +-------------+                                 |
+|                                                                             |
++-----------------------------------------------------------------------------+
+```
+
+### Components
+
+| Component | File | Description |
+|-----------|------|-------------|
+| CPU | `hdl/cpu.rb` | Top-level single-cycle CPU |
+| ALU | `hdl/alu.rb` | 32-bit ALU with 12 operations |
+| Decoder | `hdl/decoder.rb` | Instruction decoder |
+| RegisterFile | `hdl/register_file.rb` | 32x32-bit register file |
+| ImmGen | `hdl/imm_gen.rb` | Immediate value generator |
+| BranchCond | `hdl/branch_cond.rb` | Branch condition evaluator |
+| ProgramCounter | `hdl/program_counter.rb` | PC register |
+| Memory | `hdl/memory.rb` | Unified memory model |
+| Harness | `hdl/harness.rb` | Test wrapper |
+
+### CPU (`hdl/cpu.rb`)
+
+The main CPU integrates all components using RHDL's declarative DSL.
+
+**Ports:**
+```ruby
+input :clk
+input :rst
+
+# Instruction memory interface
+output :inst_addr, width: 32
+input :inst_data, width: 32
+
+# Data memory interface
+output :data_addr, width: 32
+output :data_wdata, width: 32
+input :data_rdata, width: 32
+output :data_we
+output :data_re
+output :data_funct3, width: 3
+
+# Debug outputs
+output :debug_pc, width: 32
+output :debug_inst, width: 32
+output :debug_x1, width: 32
+output :debug_x2, width: 32
+output :debug_x10, width: 32
+output :debug_x11, width: 32
+```
+
+### ALU (`hdl/alu.rb`)
+
+32-bit ALU supporting all RV32I operations.
+
+**Operations:**
+
+| Code | Operation | Description |
+|------|-----------|-------------|
+| 0 | ADD | Addition |
+| 1 | SUB | Subtraction |
+| 2 | SLL | Shift left logical |
+| 3 | SLT | Set less than (signed) |
+| 4 | SLTU | Set less than (unsigned) |
+| 5 | XOR | Bitwise XOR |
+| 6 | SRL | Shift right logical |
+| 7 | SRA | Shift right arithmetic |
+| 8 | OR | Bitwise OR |
+| 9 | AND | Bitwise AND |
+| 10 | PASS_A | Pass through A |
+| 11 | PASS_B | Pass through B |
+
+### Decoder (`hdl/decoder.rb`)
+
+Decodes instructions into control signals.
+
+**Control Signals:**
+
+| Signal | Width | Description |
+|--------|-------|-------------|
+| opcode | 7 | Instruction opcode |
+| rd | 5 | Destination register |
+| funct3 | 3 | Function code 3 |
+| rs1 | 5 | Source register 1 |
+| rs2 | 5 | Source register 2 |
+| funct7 | 7 | Function code 7 |
+| reg_write | 1 | Register write enable |
+| mem_read | 1 | Memory read enable |
+| mem_write | 1 | Memory write enable |
+| mem_to_reg | 1 | Write memory data to register |
+| alu_src | 1 | ALU source select |
+| branch | 1 | Branch instruction |
+| jump | 1 | Jump instruction |
+| jalr | 1 | JALR instruction |
+| alu_op | 4 | ALU operation code |
+
+### Immediate Generator (`hdl/imm_gen.rb`)
+
+Generates sign-extended immediate values for all instruction formats.
+
+**Formats:**
+
+| Type | Bits | Used By |
+|------|------|---------|
+| I | imm[11:0] | Load, ALU immediate, JALR |
+| S | imm[11:5], imm[4:0] | Store |
+| B | imm[12], imm[10:5], imm[4:1], imm[11] | Branch |
+| U | imm[31:12] | LUI, AUIPC |
+| J | imm[20], imm[10:1], imm[11], imm[19:12] | JAL |
+
+### Register File (`hdl/register_file.rb`)
+
+32 general-purpose 32-bit registers.
+
+**Features:**
+- x0 is hardwired to zero
+- Two read ports (rs1, rs2)
+- One write port (rd)
+- Synchronous write, asynchronous read
+
+## Architecture: Pipelined CPU
+
+### 5-Stage Pipeline
+
+```
++------+    +------+    +------+    +------+    +------+
+|  IF  |--->|  ID  |--->|  EX  |--->| MEM  |--->|  WB  |
++------+    +------+    +------+    +------+    +------+
+   |           |           |           |           |
+   v           v           v           v           v
+ Fetch      Decode      Execute     Memory     Write
+ Inst       Regs/Imm    ALU/Br      Access     Back
+```
+
+### Pipeline Stages
+
+| Stage | Description | Operations |
+|-------|-------------|------------|
+| IF | Instruction Fetch | PC -> Memory, fetch instruction |
+| ID | Instruction Decode | Decode, read registers, generate immediate |
+| EX | Execute | ALU operation, branch/jump calculation |
+| MEM | Memory Access | Load/store operations |
+| WB | Write Back | Write result to register file |
+
+### Pipeline Registers
+
+| Register | File | Contents |
+|----------|------|----------|
+| IF/ID | `if_id_reg.rb` | PC, instruction |
+| ID/EX | `id_ex_reg.rb` | Control signals, rs1/rs2 data, immediate |
+| EX/MEM | `ex_mem_reg.rb` | ALU result, memory data, control |
+| MEM/WB | `mem_wb_reg.rb` | Memory/ALU result, write enable |
+
+### Hazard Handling
+
+**Data Hazards:**
+- **Forwarding Unit** (`forwarding_unit.rb`): Forwards ALU results from EX/MEM and MEM/WB stages
+- **Stall Detection**: Detects load-use hazards requiring pipeline stall
+
+**Control Hazards:**
+- **Branch Prediction**: Predict not-taken
+- **Pipeline Flush**: Flush IF/ID on taken branch
+
+### Pipelined Components
+
+| Component | File | Description |
+|-----------|------|-------------|
+| PipelinedCPU | `pipeline/pipelined_cpu.rb` | Top-level pipelined CPU |
+| PipelinedDatapath | `pipeline/pipelined_datapath.rb` | Datapath with pipeline registers |
+| HazardUnit | `pipeline/hazard_unit.rb` | Stall and flush control |
+| ForwardingUnit | `pipeline/forwarding_unit.rb` | Data forwarding logic |
+| IF/ID Reg | `pipeline/if_id_reg.rb` | IF/ID pipeline register |
+| ID/EX Reg | `pipeline/id_ex_reg.rb` | ID/EX pipeline register |
+| EX/MEM Reg | `pipeline/ex_mem_reg.rb` | EX/MEM pipeline register |
+| MEM/WB Reg | `pipeline/mem_wb_reg.rb` | MEM/WB pipeline register |
+
+## RV32I Instruction Set
+
+### Instruction Formats
+
+```
+R-type:  |  funct7  |  rs2  |  rs1  | funct3 |   rd   | opcode |
+         |  31-25   | 24-20 | 19-15 | 14-12  |  11-7  |  6-0   |
+
+I-type:  |     imm[11:0]    |  rs1  | funct3 |   rd   | opcode |
+         |      31-20       | 19-15 | 14-12  |  11-7  |  6-0   |
+
+S-type:  |imm[11:5] |  rs2  |  rs1  | funct3 |imm[4:0]| opcode |
+         |  31-25   | 24-20 | 19-15 | 14-12  |  11-7  |  6-0   |
+
+B-type:  |imm[12|10:5]| rs2 |  rs1  | funct3 |imm[4:1|11]| opcode |
+         |   31-25    |24-20| 19-15 | 14-12  |   11-7    |  6-0   |
+
+U-type:  |          imm[31:12]          |   rd   | opcode |
+         |            31-12             |  11-7  |  6-0   |
+
+J-type:  |imm[20|10:1|11|19:12]|   rd   | opcode |
+         |        31-12        |  11-7  |  6-0   |
+```
+
+### Supported Instructions
+
+**R-Type (Register-Register):**
+
+| Instruction | funct7 | funct3 | Description |
+|-------------|--------|--------|-------------|
+| ADD | 0000000 | 000 | rd = rs1 + rs2 |
+| SUB | 0100000 | 000 | rd = rs1 - rs2 |
+| SLL | 0000000 | 001 | rd = rs1 << rs2[4:0] |
+| SLT | 0000000 | 010 | rd = (rs1 < rs2) ? 1 : 0 (signed) |
+| SLTU | 0000000 | 011 | rd = (rs1 < rs2) ? 1 : 0 (unsigned) |
+| XOR | 0000000 | 100 | rd = rs1 ^ rs2 |
+| SRL | 0000000 | 101 | rd = rs1 >> rs2[4:0] (logical) |
+| SRA | 0100000 | 101 | rd = rs1 >> rs2[4:0] (arithmetic) |
+| OR | 0000000 | 110 | rd = rs1 | rs2 |
+| AND | 0000000 | 111 | rd = rs1 & rs2 |
+
+**I-Type (Immediate):**
+
+| Instruction | funct3 | Description |
+|-------------|--------|-------------|
+| ADDI | 000 | rd = rs1 + imm |
+| SLTI | 010 | rd = (rs1 < imm) ? 1 : 0 (signed) |
+| SLTIU | 011 | rd = (rs1 < imm) ? 1 : 0 (unsigned) |
+| XORI | 100 | rd = rs1 ^ imm |
+| ORI | 110 | rd = rs1 | imm |
+| ANDI | 111 | rd = rs1 & imm |
+| SLLI | 001 | rd = rs1 << shamt |
+| SRLI | 101 | rd = rs1 >> shamt (logical) |
+| SRAI | 101 | rd = rs1 >> shamt (arithmetic) |
+
+**Load (I-Type):**
+
+| Instruction | funct3 | Description |
+|-------------|--------|-------------|
+| LB | 000 | Load byte (sign-extend) |
+| LH | 001 | Load halfword (sign-extend) |
+| LW | 010 | Load word |
+| LBU | 100 | Load byte (zero-extend) |
+| LHU | 101 | Load halfword (zero-extend) |
+
+**Store (S-Type):**
+
+| Instruction | funct3 | Description |
+|-------------|--------|-------------|
+| SB | 000 | Store byte |
+| SH | 001 | Store halfword |
+| SW | 010 | Store word |
+
+**Branch (B-Type):**
+
+| Instruction | funct3 | Description |
+|-------------|--------|-------------|
+| BEQ | 000 | Branch if rs1 == rs2 |
+| BNE | 001 | Branch if rs1 != rs2 |
+| BLT | 100 | Branch if rs1 < rs2 (signed) |
+| BGE | 101 | Branch if rs1 >= rs2 (signed) |
+| BLTU | 110 | Branch if rs1 < rs2 (unsigned) |
+| BGEU | 111 | Branch if rs1 >= rs2 (unsigned) |
+
+**Upper Immediate (U-Type):**
+
+| Instruction | Description |
+|-------------|-------------|
+| LUI | rd = imm << 12 |
+| AUIPC | rd = PC + (imm << 12) |
+
+**Jump:**
+
+| Instruction | Type | Description |
+|-------------|------|-------------|
+| JAL | J | rd = PC+4; PC = PC + imm |
+| JALR | I | rd = PC+4; PC = (rs1 + imm) & ~1 |
+
+## Assembler
+
+The assembler (`utilities/assembler.rb`) supports the full RV32I instruction set.
+
+### Usage
+
+```ruby
+require_relative 'examples/riscv/utilities/assembler'
+
+source = <<~ASM
+  .text
+  .globl _start
+
+  _start:
+      addi x1, x0, 5      # x1 = 5
+      addi x2, x0, 10     # x2 = 10
+      add  x3, x1, x2     # x3 = x1 + x2
+
+  loop:
+      beq  x3, x0, done   # if x3 == 0, jump to done
+      addi x3, x3, -1     # x3 = x3 - 1
+      j    loop           # jump to loop
+
+  done:
+      nop
+ASM
+
+program = RISCV::Assembler.assemble(source)
+# => Array of 32-bit instruction words
+```
+
+### Supported Directives
+
+| Directive | Description |
+|-----------|-------------|
+| `.text` | Code section |
+| `.data` | Data section |
+| `.globl` | Export symbol |
+| `.word` | 32-bit data |
+| `.half` | 16-bit data |
+| `.byte` | 8-bit data |
+| `.space` | Reserve bytes |
+
+### Pseudo-Instructions
+
+| Pseudo | Expansion |
+|--------|-----------|
+| `nop` | `addi x0, x0, 0` |
+| `li rd, imm` | `lui rd, imm[31:12]; addi rd, rd, imm[11:0]` |
+| `mv rd, rs` | `addi rd, rs, 0` |
+| `j offset` | `jal x0, offset` |
+| `jr rs` | `jalr x0, rs, 0` |
+| `ret` | `jalr x0, x1, 0` |
+| `call offset` | `auipc x1, offset[31:12]; jalr x1, x1, offset[11:0]` |
+
+## Verilog Export
+
+Both CPU implementations support Verilog export.
+
+### Single-Cycle CPU
+
+```ruby
+require_relative 'examples/riscv/hdl/cpu'
+
+# Generate full hierarchy
+verilog = RISCV::CPU.to_verilog_hierarchy(top_name: 'rv32i_cpu')
+File.write('rv32i_cpu.v', verilog)
+```
+
+### Pipelined CPU
+
+```ruby
+require_relative 'examples/riscv/hdl/pipeline/pipelined_cpu'
+
+verilog = RISCV::Pipeline::PipelinedDatapath.to_verilog
+File.write('rv32i_pipeline.v', verilog)
+```
+
+### Generated Module Example
+
+```verilog
+module riscv_alu(
+  input [31:0] a,
+  input [31:0] b,
+  input [3:0] op,
+  output [31:0] result,
+  output zero
+);
+  wire [31:0] add_result = a + b;
+  wire [31:0] sub_result = a - b;
+  wire [31:0] xor_result = a ^ b;
+  // ... (full implementation)
+
+  assign result = (op == 4'd0) ? add_result :
+                  (op == 4'd1) ? sub_result :
+                  // ... case select
+                  add_result;
+
+  assign zero = (result == 32'd0);
+endmodule
+```
+
+## File Structure
+
+```
+examples/riscv/
++-- hdl/                        # Single-cycle CPU
+|   +-- cpu.rb                  # Top-level CPU
+|   +-- alu.rb                  # 32-bit ALU
+|   +-- decoder.rb              # Instruction decoder
+|   +-- register_file.rb        # 32x32 register file
+|   +-- imm_gen.rb              # Immediate generator
+|   +-- branch_cond.rb          # Branch condition
+|   +-- program_counter.rb      # PC register
+|   +-- memory.rb               # Memory model
+|   +-- harness.rb              # Test harness
+|   +-- constants.rb            # ISA constants
+|   +-- pipeline/               # Pipelined CPU
+|       +-- pipelined_cpu.rb    # Top-level pipelined
+|       +-- pipelined_datapath.rb # Pipeline datapath
+|       +-- hazard_unit.rb      # Hazard detection
+|       +-- forwarding_unit.rb  # Data forwarding
+|       +-- if_id_reg.rb        # IF/ID register
+|       +-- id_ex_reg.rb        # ID/EX register
+|       +-- ex_mem_reg.rb       # EX/MEM register
+|       +-- mem_wb_reg.rb       # MEM/WB register
+|       +-- harness.rb          # Pipeline test harness
++-- utilities/
+|   +-- assembler.rb            # RV32I assembler
+```
+
+## Performance Comparison
+
+| CPU Type | CPI | Complexity | Use Case |
+|----------|-----|------------|----------|
+| Single-Cycle | 1 | Low | Education, small designs |
+| Pipelined | ~1.2* | Medium | Production, performance |
+
+*Includes stalls for hazards
+
+## Example Programs
+
+### Fibonacci
+
+```asm
+    # Compute Fibonacci sequence
+    addi x1, x0, 0      # fib(0) = 0
+    addi x2, x0, 1      # fib(1) = 1
+    addi x3, x0, 10     # n = 10
+
+loop:
+    beq  x3, x0, done
+    add  x4, x1, x2     # fib(n) = fib(n-1) + fib(n-2)
+    mv   x1, x2
+    mv   x2, x4
+    addi x3, x3, -1
+    j    loop
+
+done:
+    # x2 contains fib(10) = 55
+```
+
+### Memory Copy
+
+```asm
+    # Copy 16 bytes from src to dst
+    li   x1, 0x1000     # src
+    li   x2, 0x2000     # dst
+    addi x3, x0, 16     # count
+
+loop:
+    beq  x3, x0, done
+    lb   x4, 0(x1)      # Load byte
+    sb   x4, 0(x2)      # Store byte
+    addi x1, x1, 1
+    addi x2, x2, 1
+    addi x3, x3, -1
+    j    loop
+
+done:
+    nop
+```
+
+## References
+
+- [RISC-V Specification](https://riscv.org/technical/specifications/)
+- [Patterson & Hennessy: Computer Organization and Design, RISC-V Edition](https://www.elsevier.com/books/computer-organization-and-design-risc-v-edition/patterson/978-0-12-820331-6)
+- [RISC-V Reader](http://www.riscvbook.com/)
+
+## See Also
+
+- [MOS 6502 CPU](mos6502_cpu.md) - 8-bit 6502 implementation
+- [Game Boy Emulation](gameboy.md) - SM83 CPU implementation
+- [DSL Reference](dsl.md) - RHDL DSL documentation
+- [Export](export.md) - Verilog export guide


### PR DESCRIPTION
- Add docs/gameboy.md: Complete Game Boy (DMG/GBC/SGB) documentation
  - SM83 CPU architecture and instruction set
  - PPU, APU, timer, and memory controller details
  - MBC1-5 mapper documentation
  - CLI options and usage examples

- Add docs/riscv.md: RISC-V RV32I CPU documentation
  - Single-cycle and 5-stage pipelined architectures
  - Full RV32I instruction set reference
  - Pipeline hazard handling explanation
  - Assembler usage and Verilog export

- Update README.md with expanded Examples section
  - Add table of all 4 examples (MOS 6502, Apple II, Game Boy, RISC-V)
  - Add ASCII architecture diagrams for each example
  - Add CLI options and quick usage examples
  - Update project structure to list all examples
  - Add links to new documentation files

https://claude.ai/code/session_01X8kw2hL2BZZdujQZxvEY6X