### PR TITLE
Fix native extension loading and method references

### DIFF
--- a/examples/apple2/bin/apple2
+++ b/examples/apple2/bin/apple2
@@ -74,7 +74,7 @@ class Apple2HDLTerminal
 
     @running = false
     @last_screen = nil
-    @cycles_per_frame = options[:speed] || 100  # HDL is slow, default to small value
+    @cycles_per_frame = options[:speed]  # Speed is auto-adjusted based on backend
     @debug = options[:debug] || false
     @green_screen = options[:green] || false
     @hires_mode = options[:hires] || false
@@ -740,7 +740,7 @@ end
 
 # Parse options
 options = {
-  speed: 100,
+  speed: nil,  # nil means auto-detect based on backend
   debug: false,
   green: false,
   demo: false,
@@ -766,7 +766,7 @@ parser = OptionParser.new do |opts|
     options[:load_addr] = v.to_i(16)
   end
 
-  opts.on("-s", "--speed CYCLES", Integer, "Cycles per frame (default: 100)") do |v|
+  opts.on("-s", "--speed CYCLES", Integer, "Cycles per frame (auto: 33333 for jit/compile, 10000 for interpret, 100 for ruby)") do |v|
     options[:speed] = v
   end
 
@@ -844,6 +844,22 @@ parser = OptionParser.new do |opts|
 end
 
 parser.parse!(ARGV)
+
+# Auto-adjust speed based on backend if user didn't explicitly set --speed
+# Apple II runs at ~1MHz. At 30fps, real-time needs ~33,333 cycles/frame.
+if options[:speed].nil?
+  options[:speed] = case options[:sim]
+                    when :compile, :jit
+                      # Compiler and JIT are fast enough for real-time
+                      33_333
+                    when :interpret
+                      # Interpreter is slower, but still faster than Ruby
+                      10_000
+                    else
+                      # Ruby HDL is slow, use conservative default
+                      100
+                    end
+end
 
 terminal = Apple2HDLTerminal.new(options)
 

--- a/examples/apple2/utilities/ir_simulator_runner.rb
+++ b/examples/apple2/utilities/ir_simulator_runner.rb
@@ -91,7 +91,7 @@ module RHDL
         # PS/2 keyboard encoder for sending keys through the PS/2 protocol
         @ps2_encoder = PS2Encoder.new
 
-        @use_batched = @sim.native? && @sim.respond_to?(:run_cpu_cycles)
+        @use_batched = @sim.native? && @sim.respond_to?(:apple2_run_cpu_cycles)
 
         # Speaker audio simulation
         @speaker = Speaker.new

--- a/examples/gameboy/utilities/gameboy_ir.rb
+++ b/examples/gameboy/utilities/gameboy_ir.rb
@@ -116,7 +116,7 @@ module RHDL
         @prev_audio = 0
 
         # Check for either Game Boy batched cycles or Apple II batched cycles
-        @use_batched = @sim.native? && (@sim.respond_to?(:run_gb_cycles) || @sim.respond_to?(:run_cpu_cycles))
+        @use_batched = @sim.native? && (@sim.respond_to?(:run_gb_cycles) || @sim.respond_to?(:apple2_run_cpu_cycles))
 
         if @use_batched
           puts "  Batched execution: enabled"
@@ -227,9 +227,9 @@ module RHDL
           @sim.reset_lcd_state if @sim.respond_to?(:reset_lcd_state)
         elsif @use_batched
           poke_input('reset', 1)
-          @sim.run_cpu_cycles(1, 0, false)
+          @sim.apple2_run_cpu_cycles(1, 0, false)
           poke_input('reset', 0)
-          @sim.run_cpu_cycles(10, 0, false)
+          @sim.apple2_run_cpu_cycles(10, 0, false)
         else
           poke_input('reset', 1)
           run_cycles(10)
@@ -257,7 +257,7 @@ module RHDL
           @cycles += result[:cycles_run]
           @screen_dirty = true if result[:frames_completed] > 0
         else
-          result = @sim.run_cpu_cycles(steps, 0, false)
+          result = @sim.apple2_run_cpu_cycles(steps, 0, false)
           @cycles += result[:cycles_run]
           @screen_dirty = true if result[:screen_dirty]
         end

--- a/lib/rhdl/cli/tasks/native_task.rb
+++ b/lib/rhdl/cli/tasks/native_task.rb
@@ -236,7 +236,7 @@ module RHDL
 
         def dst_lib_name(ext)
           case host_os
-          when /darwin/ then "#{ext[:crate_name]}.bundle"
+          when /darwin/ then "#{ext[:crate_name]}.dylib"
           when /linux/ then "#{ext[:crate_name]}.so"
           when /mswin|mingw/ then "#{ext[:crate_name]}.dll"
           else "#{ext[:crate_name]}.so"


### PR DESCRIPTION
- Use .dylib extension on macOS instead of .bundle for native extensions
- Fix method name references: run_cpu_cycles -> apple2_run_cpu_cycles
- Auto-adjust Apple II speed based on simulation backend