### PR TITLE
Fix PPU counters to run even when LCD is disabled

### DIFF
--- a/examples/gameboy/hdl/ppu/video.rb
+++ b/examples/gameboy/hdl/ppu/video.rb
@@ -334,16 +334,17 @@ module GameBoy
       tile_data_hi: 0
     } do
       # Horizontal counter (0-113 at 1MHz, so 0-454 at 4MHz with h_div_cnt)
-      h_div_cnt <= mux(ce & lcdc_on, h_div_cnt + lit(1, width: 2), h_div_cnt)
+      # Note: Counters run even when LCD is off - only rendering is disabled
+      h_div_cnt <= mux(ce, h_div_cnt + lit(1, width: 2), h_div_cnt)
 
-      h_cnt <= mux(ce & lcdc_on & (h_div_cnt == lit(3, width: 2)),
+      h_cnt <= mux(ce & (h_div_cnt == lit(3, width: 2)),
                    mux(h_cnt == lit(113, width: 7),
                        lit(0, width: 7),
                        h_cnt + lit(1, width: 7)),
                    h_cnt)
 
       # Vertical counter (0-153)
-      v_cnt <= mux(ce & lcdc_on & (h_div_cnt == lit(3, width: 2)) & (h_cnt == lit(113, width: 7)),
+      v_cnt <= mux(ce & (h_div_cnt == lit(3, width: 2)) & (h_cnt == lit(113, width: 7)),
                    mux(v_cnt == lit(153, width: 8),
                        lit(0, width: 8),
                        v_cnt + lit(1, width: 8)),


### PR DESCRIPTION
The PPU horizontal and vertical counters (h_div_cnt, h_cnt, v_cnt) were gated by lcdc_on, meaning they only incremented when LCDC bit 7 was set. This caused the boot ROM to hang because it waits for VBlank (LY >= 144) before enabling the LCD, but LY never incremented with LCD off.

On real Game Boy hardware, the PPU timing counters run continuously regardless of LCD enable state - only the actual pixel rendering is disabled when LCD is off. This fix removes the lcdc_on gate from the counter increments while keeping it on the rendering logic.

https://claude.ai/code/session_01PMHz3xoqw6GzjS4KDmARL8