### PR TITLE
Synchronize Verilator runners with deterministic exports and memory handling

### DIFF
--- a/examples/mos6502/utilities/runners/verilator_runner.rb
+++ b/examples/mos6502/utilities/runners/verilator_runner.rb
@@ -323,7 +323,12 @@ module RHDL
 
       # Export MOS6502 CPU to Verilog
       verilog_file = File.join(VERILOG_DIR, 'mos6502.v')
-      unless File.exist?(verilog_file) && File.mtime(verilog_file) > File.mtime(__FILE__)
+      verilog_codegen = File.expand_path('../../../../lib/rhdl/codegen/verilog/verilog.rb', __dir__)
+      export_deps = [__FILE__, verilog_codegen].select { |p| File.exist?(p) }
+      needs_export = !File.exist?(verilog_file) ||
+                     export_deps.any? { |p| File.mtime(p) > File.mtime(verilog_file) }
+
+      if needs_export
         puts "  Exporting MOS6502 to Verilog..."
         export_verilog(verilog_file)
       end


### PR DESCRIPTION
Summary
- guard Verilog exports in the MOS6502, Apple2, and Gameboy runners with dependency timestamps and shared codegen metadata
- match Apple2 runner cycle handling to the IR batched runner by reading CPU address regs, adding derived clock ticks, and exposing more peekable signals
- add SystemC stub for Gameboy runner, initialize memories during Verilog generation, and simplify run/reset behavior

Testing
- Not run (not requested)