### PR TITLE
Align Verilator runners initialization behavior

### DIFF
--- a/examples/mos6502/utilities/runners/verilator_runner.rb
+++ b/examples/mos6502/utilities/runners/verilator_runner.rb
@@ -52,8 +52,6 @@ module RHDL
 
       # Memory array (64KB)
       @memory = Array.new(65536, 0)
-
-      reset_simulation
     end
 
     def native?


### PR DESCRIPTION
## Summary
- remove the double initialization by skipping the extra `reset_simulation` call in the MOS 6502 Verilator runner so it matches the other runners
- ensure all runners follow the same startup semantics as requested

## Testing
- Not run (not requested)