### PR TITLE
Improve color rendering quality for Apple II terminal

### DIFF
--- a/examples/apple2/bin/apple2
+++ b/examples/apple2/bin/apple2
@@ -22,6 +22,7 @@ options = {
   hires: false,
   hires_width: nil,  # Auto-calculated based on mode and terminal size
   color: false,  # NTSC artifact color rendering
+  composite: false, # Optional horizontal low-pass filter for color mode
   audio: false,  # Audio output disabled by default
   mode: :hdl,  # Simulation mode: :hdl (default), :netlist
   sim: :ruby   # Simulator backend: :ruby (default), :interpret, :jit, :compile
@@ -76,6 +77,10 @@ parser = OptionParser.new do |opts|
   opts.on("-C", "--color", "Enable NTSC artifact color rendering (implies --hires)") do
     options[:color] = true
     options[:hires] = true
+  end
+
+  opts.on("--composite", "Apply composite-like horizontal blur in color mode (reduces speckle/shimmer)") do
+    options[:composite] = true
   end
 
   opts.on("--hires-width WIDTH", Integer, "Hi-res display width in chars (auto-adjusts to terminal)") do |v|

--- a/examples/apple2/utilities/runners/hdl_runner.rb
+++ b/examples/apple2/utilities/runners/hdl_runner.rb
@@ -299,8 +299,8 @@ module RHDL
 
       # Render hi-res screen with NTSC artifact colors
       # chars_wide: target width in characters (default 140)
-      def render_hires_color(chars_wide: 140)
-        renderer = ColorRenderer.new(chars_wide: chars_wide)
+      def render_hires_color(chars_wide: 140, composite: false)
+        renderer = ColorRenderer.new(chars_wide: chars_wide, composite: composite)
         renderer.render(@ram, base_addr: HIRES_PAGE1_START)
       end
 

--- a/examples/apple2/utilities/runners/headless_runner.rb
+++ b/examples/apple2/utilities/runners/headless_runner.rb
@@ -142,8 +142,8 @@ module RHDL
       end
 
       # Delegate hi-res rendering to runner
-      def render_hires_color(chars_wide: 140)
-        @runner.render_hires_color(chars_wide: chars_wide)
+      def render_hires_color(chars_wide: 140, composite: false)
+        @runner.render_hires_color(chars_wide: chars_wide, composite: composite)
       end
 
       def render_hires_braille(chars_wide: 80, invert: false)

--- a/examples/apple2/utilities/runners/ir_runner.rb
+++ b/examples/apple2/utilities/runners/ir_runner.rb
@@ -458,15 +458,15 @@ module RHDL
 
       # Render hi-res screen with NTSC artifact colors
       # chars_wide: target width in characters (default 140)
-      def render_hires_color(chars_wide: 140)
+      def render_hires_color(chars_wide: 140, composite: false)
         if @use_batched
-          render_hires_color_batched(chars_wide)
+          render_hires_color_batched(chars_wide, composite: composite)
         else
-          render_hires_color_fallback(chars_wide)
+          render_hires_color_fallback(chars_wide, composite: composite)
         end
       end
 
-      def render_hires_color_batched(chars_wide)
+      def render_hires_color_batched(chars_wide, composite: false)
         # Build a RAM array with hi-res page data from Rust backend
         # ColorRenderer needs the full address space since it uses hires_line_address()
         hires_ram = Array.new(HIRES_PAGE1_END + 1, 0)
@@ -476,13 +476,13 @@ module RHDL
         hires_data = @sim.apple2_read_ram(HIRES_PAGE1_START, HIRES_PAGE1_END - HIRES_PAGE1_START + 1).to_a
         hires_data.each_with_index { |b, i| hires_ram[HIRES_PAGE1_START + i] = b }
 
-        renderer = ColorRenderer.new(chars_wide: chars_wide)
+        renderer = ColorRenderer.new(chars_wide: chars_wide, composite: composite)
         renderer.render(hires_ram, base_addr: HIRES_PAGE1_START)
       end
 
-      def render_hires_color_fallback(chars_wide)
+      def render_hires_color_fallback(chars_wide, composite: false)
         @ram ||= Array.new(48 * 1024, 0)
-        renderer = ColorRenderer.new(chars_wide: chars_wide)
+        renderer = ColorRenderer.new(chars_wide: chars_wide, composite: composite)
         renderer.render(@ram, base_addr: HIRES_PAGE1_START)
       end
 

--- a/examples/apple2/utilities/runners/verilator_runner.rb
+++ b/examples/apple2/utilities/runners/verilator_runner.rb
@@ -322,8 +322,8 @@ module RHDL
         lines.join("\n")
       end
 
-      def render_hires_color(chars_wide: 140)
-        renderer = ColorRenderer.new(chars_wide: chars_wide)
+      def render_hires_color(chars_wide: 140, composite: false)
+        renderer = ColorRenderer.new(chars_wide: chars_wide, composite: composite)
         renderer.render(@ram, base_addr: HIRES_PAGE1_START)
       end
 

--- a/examples/apple2/utilities/tasks/run_task.rb
+++ b/examples/apple2/utilities/tasks/run_task.rb
@@ -66,6 +66,7 @@ module RHDL
           @green_screen = options[:green] || false
           @hires_mode = options[:hires] || false
           @color_mode = options[:color] || false
+          @composite = options[:composite] || false
           @audio_enabled = options[:audio] || false
 
           # Terminal size and padding for centering
@@ -117,7 +118,7 @@ module RHDL
 
           # Auto-adjust hires width to fit terminal
           # Use preferred width if set, otherwise use mode-appropriate default capped to terminal
-          default_width = @color_mode ? 140 : 80
+          default_width = @color_mode ? 280 : 80
           preferred = @preferred_hires_width || default_width
           @hires_width = [preferred, @term_cols].min
 
@@ -415,7 +416,7 @@ module RHDL
 
           # Render hi-res using color or braille characters
           if @color_mode
-            hires_output = @runner.render_hires_color(chars_wide: @hires_width)
+            hires_output = @runner.render_hires_color(chars_wide: @hires_width, composite: @composite)
           else
             hires_output = @runner.render_hires_braille(chars_wide: @hires_width, invert: true)
           end

--- a/examples/mos6502/bin/mos6502
+++ b/examples/mos6502/bin/mos6502
@@ -99,8 +99,9 @@ class Apple2Terminal
     @green_screen = options[:green] || false
     @hires_mode = options[:hires] || false
     @color_mode = options[:color] || false
+    @composite = options[:composite] || false
     @preferred_hires_width = options[:hires_width]
-    @hires_width = @preferred_hires_width || (@color_mode ? 140 : 80)
+    @hires_width = @preferred_hires_width || (@color_mode ? 280 : 80)
     @audio_enabled = options[:audio] != false
 
     # Terminal size and padding for centering
@@ -151,7 +152,7 @@ class Apple2Terminal
 
     # Auto-adjust hires width to fit terminal
     # Use preferred width if set, otherwise use mode-appropriate default capped to terminal
-    default_width = @color_mode ? 140 : 80
+    default_width = @color_mode ? 280 : 80
     preferred = @preferred_hires_width || default_width
     @hires_width = [preferred, @term_cols].min
 
@@ -488,7 +489,7 @@ class Apple2Terminal
 
     # Render hi-res using color or braille characters
     if @color_mode
-      hires_output = @runner.bus.render_hires_color(chars_wide: @hires_width)
+      hires_output = @runner.bus.render_hires_color(chars_wide: @hires_width, composite: @composite)
     elsif @runner.native? && @runner.respond_to?(:cpu) && @runner.cpu.respond_to?(:render_hires_braille)
       # Use fast Rust rendering when available (native mode)
       hires_output = @runner.cpu.render_hires_braille(@hires_width, true)
@@ -925,11 +926,12 @@ options = {
   hires: false,
   hires_width: nil,  # Auto-calculated based on mode and terminal size
   color: false,  # NTSC artifact color rendering
+  composite: false, # Optional horizontal low-pass filter for color mode
   audio: true  # Audio enabled by default
 }
 
 parser = OptionParser.new do |opts|
-  opts.banner = "Usage: bin/apple2 [options] [program.bin]"
+  opts.banner = "Usage: bin/mos6502 [options] [program.bin]"
   opts.separator ""
   opts.separator "Apple ][ Terminal Emulator - 6502 CPU Simulation"
   opts.separator ""
@@ -978,6 +980,10 @@ parser = OptionParser.new do |opts|
   opts.on("-C", "--color", "Enable NTSC artifact color rendering (implies --hires)") do
     options[:color] = true
     options[:hires] = true
+  end
+
+  opts.on("--composite", "Apply composite-like horizontal blur in color mode (reduces speckle/shimmer)") do
+    options[:composite] = true
   end
 
   opts.on("--hires-width WIDTH", Integer, "Hi-res display width in chars (auto-adjusts to terminal)") do |v|

--- a/examples/mos6502/utilities/apple2/bus.rb
+++ b/examples/mos6502/utilities/apple2/bus.rb
@@ -407,10 +407,10 @@ module RHDL
 
     # Render hi-res screen using NTSC artifact colors
     # Uses half-block characters with truecolor ANSI escape sequences
-    # chars_wide: target width in characters (default 140 = full resolution)
-    def render_hires_color(chars_wide: 140)
+    # chars_wide: target width in characters (default 140, try 280 for max detail)
+    def render_hires_color(chars_wide: 140, composite: false)
       base = hires_page_base
-      renderer = ColorRenderer.new(chars_wide: chars_wide)
+      renderer = ColorRenderer.new(chars_wide: chars_wide, composite: composite)
 
       # Build memory accessor that uses mem_read for native CPU support
       ram = ->(addr) { mem_read(addr) }

--- a/examples/mos6502/utilities/tasks/run_task.rb
+++ b/examples/mos6502/utilities/tasks/run_task.rb
@@ -59,8 +59,9 @@ module RHDL
         @green_screen = options[:green] || false
         @hires_mode = options[:hires] || false
         @color_mode = options[:color] || false
+        @composite = options[:composite] || false
         @preferred_hires_width = options[:hires_width]
-        @hires_width = @preferred_hires_width || (@color_mode ? 140 : 80)
+        @hires_width = @preferred_hires_width || (@color_mode ? 280 : 80)
         @audio_enabled = options[:audio] != false
 
         # Terminal size and padding for centering
@@ -124,7 +125,7 @@ module RHDL
         @pad_left = [(@term_cols - DISPLAY_WIDTH) / 2, 0].max
 
         # Auto-adjust hires width to fit terminal
-        default_width = @color_mode ? 140 : 80
+        default_width = @color_mode ? 280 : 80
         preferred = @preferred_hires_width || default_width
         @hires_width = [preferred, @term_cols].min
 
@@ -389,7 +390,7 @@ module RHDL
         end
 
         if @color_mode
-          hires_output = @runner.bus.render_hires_color(chars_wide: @hires_width)
+          hires_output = @runner.bus.render_hires_color(chars_wide: @hires_width, composite: @composite)
         elsif @runner.native? && @runner.respond_to?(:cpu) && @runner.cpu.respond_to?(:render_hires_braille)
           hires_output = @runner.cpu.render_hires_braille(@hires_width, true)
         else


### PR DESCRIPTION
Summary:
- bump default hi-res width to 280 when using color mode and expose a `--composite` flag to toggle an optional horizontal blur that reduces shimmer
- enhance `ColorRenderer` with configurable downscaling modes (sample/majority/average/auto), smarter black detection, and the new blur filter, then thread the option through all runners/tasks
- favor averaging/majority sampling over single-pixel picks when mapping hi-res pixels to terminal columns for more consistent artifact colors

Testing:
- Not run (not requested)