### PR TITLE
web: async runner load + default RISC-V compiler backend

### DIFF
--- a/web/app/components/shell/bindings/app_bindings.mjs
+++ b/web/app/components/shell/bindings/app_bindings.mjs
@@ -57,6 +57,17 @@ export function bindCoreBindings({
     startY: 0,
     startHeight: 0
   };
+  let runnerLoadInProgress = false;
+
+  async function yieldToUi() {
+    if (globalWindow && typeof globalWindow.requestAnimationFrame === 'function') {
+      await new Promise((resolve) => {
+        globalWindow.requestAnimationFrame(() => resolve());
+      });
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
 
   function terminalMaxHeightPx() {
     const viewportHeight = Number(globalWindow?.innerHeight || 0);
@@ -88,8 +99,26 @@ export function bindCoreBindings({
     }
   }
 
-  listeners.on(dom.loadRunnerBtn, 'click', () => {
-    runner.loadPreset();
+  listeners.on(dom.loadRunnerBtn, 'click', async () => {
+    if (runnerLoadInProgress) {
+      return;
+    }
+    runnerLoadInProgress = true;
+    if (dom.loadRunnerBtn) {
+      dom.loadRunnerBtn.disabled = true;
+    }
+    if (dom.runnerStatus) {
+      dom.runnerStatus.textContent = 'Loading...';
+    }
+    try {
+      await yieldToUi();
+      await runner.loadPreset();
+    } finally {
+      runnerLoadInProgress = false;
+      if (dom.loadRunnerBtn) {
+        dom.loadRunnerBtn.disabled = false;
+      }
+    }
   });
 
   listeners.on(dom.sidebarToggleBtn, 'click', () => {
@@ -278,7 +307,13 @@ export function bindCoreBindings({
   });
 
   listeners.on(dom.runnerSelect, 'change', () => {
-    store.setRunnerPresetState(runner.getPreset(dom.runnerSelect.value).id);
+    const preset = runner.getPreset(dom.runnerSelect.value);
+    store.setRunnerPresetState(preset.id);
+    const preferredBackend = String(preset?.preferredBackend || '').trim();
+    if (preferredBackend && dom.backendSelect) {
+      dom.backendSelect.value = preferredBackend;
+      store.setBackendState(preferredBackend);
+    }
     runner.updateIrSourceVisibility();
     sim.refreshStatus();
   });

--- a/web/test/components/shell/bindings/app_bindings.test.mjs
+++ b/web/test/components/shell/bindings/app_bindings.test.mjs
@@ -1,0 +1,177 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { bindCoreBindings } from '../../../../app/components/shell/bindings/app_bindings.mjs';
+
+function makeTarget(extra = {}) {
+  return Object.assign(new EventTarget(), extra);
+}
+
+function makeDom() {
+  return {
+    loadRunnerBtn: makeTarget({ disabled: false }),
+    runnerStatus: { textContent: 'Runner not initialized' },
+    sidebarToggleBtn: makeTarget(),
+    terminalToggleBtn: makeTarget(),
+    terminalResizeHandle: makeTarget(),
+    terminalPanel: {
+      style: {},
+      getBoundingClientRect: () => ({ height: 400 })
+    },
+    terminalOutput: makeTarget(),
+    themeSelect: makeTarget({ value: 'shenzhen' }),
+    backendSelect: makeTarget({ value: 'interpreter' }),
+    simStatus: { textContent: '' },
+    backendStatus: { textContent: '' },
+    runnerSelect: makeTarget({ value: 'generic' }),
+    loadSampleBtn: makeTarget(),
+    sampleSelect: makeTarget({ value: '' }),
+    irJson: { value: '' },
+    tabButtons: []
+  };
+}
+
+function makeBindings(dom, overrides = {}) {
+  const state = {
+    sidebarCollapsed: false,
+    terminalOpen: true,
+    backend: 'interpreter',
+    terminal: { uartPassthrough: false }
+  };
+
+  const calls = [];
+  let resolveLoad;
+  let loadPromise = Promise.resolve();
+
+  const runner = {
+    loadPreset: () => loadPromise,
+    getPreset: (id) => ({ id, preferredBackend: '' }),
+    updateIrSourceVisibility: () => calls.push(['updateIrSourceVisibility']),
+    currentPreset: () => ({ usesManualIr: false }),
+    ensureBackendInstance: async () => {},
+    loadBundle: async () => ({
+      simJson: '{}',
+      explorerJson: '{}',
+      explorerMeta: null,
+      sourceBundle: null,
+      schematicBundle: null
+    }),
+    loadSample: () => calls.push(['loadSample'])
+  };
+
+  const store = {
+    setRunnerPresetState: (value) => calls.push(['setRunnerPresetState', value]),
+    setBackendState: (value) => {
+      state.backend = value;
+      calls.push(['setBackendState', value]);
+    }
+  };
+
+  const shell = {
+    setSidebarCollapsed: () => {},
+    setTerminalOpen: () => {},
+    submitTerminalInput: async () => {},
+    terminalHistoryNavigate: () => {},
+    terminalBackspaceInput: () => {},
+    terminalFocusInput: () => {},
+    terminalAppendInput: () => {},
+    applyTheme: () => {},
+    setActiveTab: () => {}
+  };
+
+  const util = {
+    getBackendDef: (id) => ({ id, label: id })
+  };
+
+  const base = {
+    dom,
+    state,
+    shell,
+    runner,
+    sim: {
+      refreshStatus: () => calls.push(['refreshStatus']),
+      initializeSimulator: async () => {}
+    },
+    apple2: {
+      queueKey: () => {},
+      refreshMemoryView: () => {}
+    },
+    components: {
+      refreshExplorer: () => {}
+    },
+    store,
+    util,
+    log: () => {}
+  };
+
+  if (overrides.loadPresetDeferred) {
+    loadPromise = new Promise((resolve) => {
+      resolveLoad = resolve;
+    });
+  }
+
+  Object.assign(base, overrides);
+
+  const teardown = bindCoreBindings(base);
+  return { teardown, calls, state, resolveLoad };
+}
+
+test('load button shows loading state and disables while runner preset loads', async () => {
+  const dom = makeDom();
+  const { resolveLoad } = makeBindings(dom, { loadPresetDeferred: true });
+
+  dom.loadRunnerBtn.dispatchEvent(new Event('click'));
+  await Promise.resolve();
+
+  assert.equal(dom.loadRunnerBtn.disabled, true);
+  assert.equal(dom.runnerStatus.textContent, 'Loading...');
+
+  resolveLoad();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await Promise.resolve();
+
+  assert.equal(dom.loadRunnerBtn.disabled, false);
+});
+
+test('runner selection applies preferred backend to backend selector and store state', () => {
+  const dom = makeDom();
+  const calls = [];
+  const { teardown } = makeBindings(dom, {
+    runner: {
+      loadPreset: async () => {},
+      getPreset: (id) => ({ id, preferredBackend: 'compiler' }),
+      updateIrSourceVisibility: () => calls.push(['updateIrSourceVisibility']),
+      currentPreset: () => ({ usesManualIr: false }),
+      ensureBackendInstance: async () => {},
+      loadBundle: async () => ({
+        simJson: '{}',
+        explorerJson: '{}',
+        explorerMeta: null,
+        sourceBundle: null,
+        schematicBundle: null
+      }),
+      loadSample: () => {}
+    },
+    store: {
+      setRunnerPresetState: (value) => calls.push(['setRunnerPresetState', value]),
+      setBackendState: (value) => calls.push(['setBackendState', value])
+    },
+    sim: {
+      refreshStatus: () => calls.push(['refreshStatus']),
+      initializeSimulator: async () => {}
+    }
+  });
+
+  dom.runnerSelect.value = 'riscv';
+  dom.runnerSelect.dispatchEvent(new Event('change'));
+
+  assert.equal(dom.backendSelect.value, 'compiler');
+  assert.deepEqual(calls, [
+    ['setRunnerPresetState', 'riscv'],
+    ['setBackendState', 'compiler'],
+    ['updateIrSourceVisibility'],
+    ['refreshStatus']
+  ]);
+
+  teardown();
+});


### PR DESCRIPTION
### Motivation

- Prevent the browser UI from freezing when loading large compiler assets for RISC-V/xv6/Linux runners by making the runner load non-blocking and showing a clear loading indicator. 
- Ensure RISC-V presets that ship with a `preferredBackend: "compiler"` actually select the compiler backend in the UI when the preset is chosen.

### Description

- Make the Load button handler asynchronous and non-blocking by adding a `yieldToUi()` helper (uses `requestAnimationFrame` with a `setTimeout(0)` fallback) so the UI can render the `Loading...` indicator before heavy async work begins. 
- Add a `runnerLoadInProgress` guard to prevent concurrent loads and disable/reenable the Load button while loading, and set `runnerStatus` to `Loading...` during the process. 
- Apply each runner preset's `preferredBackend` immediately when the runner is selected by reading `runner.getPreset(...)`, setting `dom.backendSelect.value`, and calling `store.setBackendState(...)` on `runnerSelect` changes. 
- Add unit tests in `web/test/components/shell/bindings/app_bindings.test.mjs` that verify the Load button disable/loading indicator lifecycle and that runner selection applies `preferredBackend` to the backend selector and store state.

### Testing

- Ran the new unit tests with `cd web && node --test test/components/shell/bindings/app_bindings.test.mjs`, and both tests passed. 
- Attempted an automated Playwright run to capture the UI load indicator (screenshot) but the headless browser crashed in this environment (SIGSEGV); the test run failed due to the environment/browser crash rather than the code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f86ed376c832cae8c0217f781d755)