### PR TITLE
Add cpu8bit ArcToGPU runner path with checks and benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ lib/rhdl/codegen/ir/sim/ir_compiler/*.json
 
 # Arcilator build artifacts
 .arcilator_build/
+.arcilator_gpu_build/
 
 # HDL build artifacts (Verilator/Arcilator for example systems)
 .hdl_build/

--- a/README.md
+++ b/README.md
@@ -612,10 +612,11 @@ See [Simulation](docs/simulation.md) and [Gate-Level Backend](docs/gate_level_ba
 RHDL includes benchmarking tasks to measure simulation performance across backends:
 
 ```bash
-rake bench                    # Benchmark gate-level simulation
-rake bench[mos6502,cycles]    # Benchmark MOS 6502 CPU
-rake bench[apple2,cycles]     # Benchmark Apple II full system
-rake bench[gameboy,frames]    # Benchmark GameBoy with Prince of Persia
+rake bench:native[gates]             # Benchmark gate-level simulation
+rake bench:native[cpu8bit,cycles]    # Benchmark 8-bit CPU FastHarness (compiler vs arcilator_gpu)
+rake bench:native[mos6502,cycles]    # Benchmark MOS 6502 CPU
+rake bench:native[apple2,cycles]     # Benchmark Apple II full system
+rake bench:native[gameboy,frames]    # Benchmark GameBoy with Prince of Persia
 rake bench:web[apple2,cycles] # Benchmark Apple II web WASM backends
 rake bench:web[riscv,cycles]  # Benchmark RISC-V web WASM backends
 ```
@@ -647,10 +648,16 @@ bundle exec rake pspec[riscv]          # Run RISC-V specs in parallel
 
 # Test and simulation benchmarks
 bundle exec rake spec:bench[riscv,20]  # Benchmark 20 RISC-V spec files
-bundle exec rake bench[ir,5000000]     # Benchmark IR runners
-bundle exec rake bench                  # Benchmark gate-level simulation
+bundle exec rake bench:native[ir,5000000]     # Benchmark IR runners
+bundle exec rake bench:native[gates]          # Benchmark gate-level simulation
+bundle exec rake bench:native[cpu8bit,5000000] # Benchmark 8-bit CPU compiler vs arcilator_gpu
 bundle exec rake bench:web[apple2]     # Benchmark Apple II web compiler vs arcilator vs verilator
 bundle exec rake bench:web[riscv]      # Benchmark RISC-V web compiler vs arcilator vs verilator
+
+# Dependency checks
+bundle exec rake deps:check             # General dependency status
+bundle exec rake deps:check_gpu         # Fail-fast ArcToGPU toolchain check
+RHDL_ENABLE_ARCILATOR_GPU=1 bundle exec rspec spec/examples/8bit/hdl/cpu/arcilator_gpu_parity_spec.rb # Enable ArcToGPU parity test
 
 # Native backends
 bundle exec rake native:build          # Build native extensions

--- a/Rakefile
+++ b/Rakefile
@@ -405,11 +405,17 @@ namespace :deps do
     load_cli_tasks
     RHDL::CLI::Tasks::DepsTask.new(check: true).run
   end
+
+  desc "Fail-fast ArcToGPU toolchain check (arcilator_gpu prerequisites)"
+  task :check_gpu do
+    load_cli_tasks
+    RHDL::CLI::Tasks::DepsTask.new(check_gpu: true, strict_gpu: true).run
+  end
 end
 
 # Benchmarking
 namespace :bench do
-  desc "Benchmark by scope (gates, mos6502, apple2, gameboy, ir, riscv)"
+  desc "Benchmark by scope (gates, cpu8bit, mos6502, apple2, gameboy, ir, riscv)"
   task :native, [:scope, :count] do |_, args|
     load_cli_tasks
 
@@ -419,6 +425,9 @@ namespace :bench do
     case scope
     when :gates
       RHDL::CLI::Tasks::BenchmarkTask.new(type: :gates).run
+    when :cpu8bit
+      cycles = count || 5_000_000
+      RHDL::CLI::Tasks::BenchmarkTask.new(type: :cpu8bit, cycles: cycles).run
     when :mos6502
       cycles = count || 5_000_000
       RHDL::CLI::Tasks::BenchmarkTask.new(type: :mos6502, cycles: cycles).run
@@ -436,7 +445,7 @@ namespace :bench do
       RHDL::CLI::Tasks::BenchmarkTask.new(type: :riscv, cycles: cycles).run
     else
       puts "Unknown benchmark scope '#{scope}'."
-      puts "Available scopes: gates, mos6502, apple2, gameboy, ir, riscv"
+      puts "Available scopes: gates, cpu8bit, mos6502, apple2, gameboy, ir, riscv"
       exit 1
     end
   end

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -78,7 +78,8 @@ The GameBoy runs at 4.19 MHz, so backends achieving >100% can run faster than re
 Benchmarks low-level gate simulation:
 
 ```bash
-rake bench                      # Gate-level toggle benchmark
+rake bench:native[gates]        # Gate-level toggle benchmark
+rake bench:native[cpu8bit]      # 8-bit CPU FastHarness benchmark
 ```
 
 ### Web WASM Backend Benchmarks

--- a/docs/simulation.md
+++ b/docs/simulation.md
@@ -639,16 +639,20 @@ end
 
 ```bash
 # Gate-level simulation benchmark
-rake bench
-RHDL_BENCH_LANES=128 RHDL_BENCH_CYCLES=1000000 rake bench
+rake bench:native[gates]
+RHDL_BENCH_LANES=128 RHDL_BENCH_CYCLES=1000000 rake bench:native[gates]
+
+# 8-bit CPU FastHarness benchmark
+rake bench:native[cpu8bit]
+rake bench:native[cpu8bit,5000000]  # 5M cycles
 
 # MOS6502 CPU benchmark
-rake bench[mos6502]
-rake bench[mos6502,5000000]  # 5M cycles
+rake bench:native[mos6502]
+rake bench:native[mos6502,5000000]  # 5M cycles
 
 # Apple II full system benchmark
-rake bench[apple2]
-rake bench[apple2,2000000]  # 2M cycles
+rake bench:native[apple2]
+rake bench:native[apple2,2000000]  # 2M cycles
 
 # Legacy alias removed (use bench scopes)
 

--- a/examples/8bit/hdl/cpu/harness.rb
+++ b/examples/8bit/hdl/cpu/harness.rb
@@ -36,29 +36,85 @@ module RHDL
         end
       end
 
+      # 64K memory view backed by the native runner memory ABI.
+      class RunnerMemory64K
+        def initialize(sim)
+          @sim = sim
+        end
+
+        def read(addr)
+          @sim.runner_read_memory(addr & 0xFFFF, 1, mapped: false).first.to_i & 0xFF
+        end
+        alias read_mem read
+
+        def write(addr, value)
+          @sim.runner_write_memory(addr & 0xFFFF, [value & 0xFF], mapped: false)
+          value & 0xFF
+        end
+        alias write_mem write
+
+        def load(program, start_addr = 0)
+          bytes = program.is_a?(String) ? program.b.bytes : Array(program)
+          return if bytes.empty?
+
+          @sim.runner_load_memory(bytes, start_addr & 0xFFFF, false)
+        end
+      end
+
       # Fast Harness using IR Compiler for high-performance simulation
       # Uses native Rust backend instead of Ruby behavioral simulation
       class FastHarness
         attr_reader :memory, :halted, :cycle_count
+
+        def self.arcilator_gpu_status
+          require_relative '../../utilities/runners/arcilator_gpu_runner'
+          RHDL::Examples::CPU8Bit::ArcilatorGpuRunner.status
+        rescue LoadError, NameError => e
+          {
+            ready: false,
+            missing_tools: [],
+            missing_capabilities: ["arcilator_gpu runner unavailable: #{e.message}"]
+          }
+        end
+
+        def self.ensure_arcilator_gpu_available!
+          status = arcilator_gpu_status
+          return true if status[:ready]
+
+          details = []
+          details << "missing tools: #{status[:missing_tools].join(', ')}" unless status[:missing_tools].empty?
+          details << "missing capabilities: #{status[:missing_capabilities].join(', ')}" unless status[:missing_capabilities].empty?
+          raise ArgumentError,
+            "arcilator_gpu backend unavailable (#{details.join('; ')}). " \
+            "Install an ArcToGPU-enabled arcilator build plus Metal/SPIR-V toolchain support."
+        end
 
         def initialize(external_memory = nil, sim: :compile)
           require 'rhdl/codegen'
 
           @cycle_count = 0
           @halted = false
-          @memory = Memory64K.new
-          @sim_backend = sim
+          @sim_backend = normalize_sim_backend(sim)
 
-          # Generate IR from CPU component
-          ir = RHDL::HDL::CPU::CPU.to_flat_ir
-          ir_json = RHDL::Codegen::IR::IRToJson.convert(ir)
+          if arcilator_gpu_mode?
+            self.class.ensure_arcilator_gpu_available!
+            require_relative '../../utilities/runners/arcilator_gpu_runner'
+            @sim = RHDL::Examples::CPU8Bit::ArcilatorGpuRunner.new
+            @memory = RunnerMemory64K.new(@sim)
+            ensure_runner_cpu8bit_mode!
+          else
+            # Generate IR from CPU component
+            ir = RHDL::HDL::CPU::CPU.to_flat_ir
+            ir_json = RHDL::Codegen::IR::IRToJson.convert(ir)
 
-          require 'rhdl/codegen/ir/sim/ir_simulator'
-          @sim = RHDL::Codegen::IR::IrSimulator.new(
-            ir_json,
-            backend: sim,
-            allow_fallback: true
-          )
+            require 'rhdl/codegen/ir/sim/ir_simulator'
+            @sim = RHDL::Codegen::IR::IrSimulator.new(
+              ir_json,
+              backend: simulator_backend,
+              allow_fallback: true
+            )
+            @memory = Memory64K.new
+          end
 
           # Copy external memory if provided
           if external_memory && !external_memory.is_a?(String)
@@ -76,7 +132,7 @@ module RHDL
         end
 
         def backend
-          @sim.backend
+          arcilator_gpu_mode? ? :arcilator_gpu : @sim.backend
         end
 
         # Read CPU state
@@ -116,6 +172,15 @@ module RHDL
           @halted = false
           @cycle_count = 0
 
+          if arcilator_gpu_mode?
+            @sim.poke('rst', 1)
+            run_runner_cycles(1)
+            @sim.poke('rst', 0)
+            @sim.evaluate
+            @halted = true if @sim.peek('halted') == 1
+            return
+          end
+
           @sim.poke('rst', 1)
           @sim.poke('mem_data_in', 0)
           clock_cycle
@@ -124,6 +189,12 @@ module RHDL
         end
 
         def clock_cycle
+          if arcilator_gpu_mode?
+            run_runner_cycles(1)
+            @halted = true if @sim.peek('halted') == 1
+            return
+          end
+
           # Get memory address and control signals
           addr = @sim.peek('mem_addr')
           write_en = @sim.peek('mem_write_en')
@@ -147,6 +218,43 @@ module RHDL
 
           # Check for halt
           @halted = true if @sim.peek('halted') == 1
+        end
+
+        def run_cycles(count, batch_size: 1024)
+          n = count.to_i
+          return 0 if n <= 0
+
+          unless arcilator_gpu_mode?
+            ran = 0
+            n.times do
+              break if @halted
+
+              clock_cycle
+              ran += 1
+              @cycle_count += 1
+            end
+            return ran
+          end
+
+          remaining = n
+          ran = 0
+          batch = [batch_size.to_i, 1].max
+          while remaining.positive?
+            step = [remaining, batch].min
+            batch_ran = run_runner_cycles(step)
+            break if batch_ran <= 0
+
+            ran += batch_ran
+            remaining -= batch_ran
+            if @sim.peek('halted') == 1
+              @halted = true
+              break
+            end
+          end
+
+          @cycle_count += ran
+          @halted = true if @sim.peek('halted') == 1
+          ran
         end
 
         def run(max_cycles = 10000)
@@ -176,6 +284,41 @@ module RHDL
         def get_input(name)
           # Not directly supported in IR sim
           0
+        end
+
+        private
+
+        def normalize_sim_backend(sim)
+          sym = sim.to_sym
+          return :compile if sym == :compiler
+
+          sym
+        end
+
+        def simulator_backend
+          @sim_backend
+        end
+
+        def arcilator_gpu_mode?
+          @sim_backend == :arcilator_gpu
+        end
+
+        def ensure_runner_cpu8bit_mode!
+          return if @sim.runner_mode? && @sim.runner_kind == :cpu8bit
+
+          raise ArgumentError,
+            "arcilator_gpu backend requires native cpu8bit runner mode " \
+            "(runner_mode=#{@sim.runner_mode?}, runner_kind=#{@sim.runner_kind.inspect})"
+        end
+
+        def run_runner_cycles(n)
+          result = @sim.runner_run_cycles(n, 0, false)
+          cycles = if result.is_a?(Hash)
+            result.fetch(:cycles_run, n).to_i
+          else
+            n
+          end
+          [[cycles, 0].max, n].min
         end
       end
 

--- a/examples/8bit/utilities/runners/arcilator_gpu_runner.rb
+++ b/examples/8bit/utilities/runners/arcilator_gpu_runner.rb
@@ -1,0 +1,570 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'fiddle'
+require 'json'
+require 'open3'
+require 'rbconfig'
+require 'shellwords'
+require 'rhdl/codegen'
+require_relative '../../hdl/cpu/cpu'
+
+module RHDL
+  module Examples
+    module CPU8Bit
+      # Native runner for 8-bit CPU using arcilator ArcToGPU lowering.
+      #
+      # Pipeline:
+      #   RHDL CPU -> FIRRTL -> firtool (HW MLIR) -> arcilator (ArcToGPU LLVM IR)
+      #   -> clang/llc object -> C++ shim .so/.dylib -> Fiddle
+      class ArcilatorGpuRunner
+        BUILD_DIR = File.expand_path('../../.arcilator_gpu_build', __dir__)
+
+        REQUIRED_TOOLS = %w[firtool arcilator mlir-opt spirv-cross].freeze
+        GPU_OPTION_PATTERNS = [
+          '--arc-to-gpu',
+          '--lowering=arc-to-gpu',
+          '--arc-lowering=to-gpu',
+          '--lower-arc-to-gpu'
+        ].freeze
+
+        REQUIRED_SIGNAL_NAMES = %w[
+          clk
+          rst
+          mem_addr
+          mem_data_in
+          mem_data_out
+          mem_write_en
+          halted
+          pc_out
+          acc_out
+          sp_out
+          state_out
+          zero_flag_out
+        ].freeze
+
+        attr_reader :backend
+
+        def self.status
+          missing_tools = REQUIRED_TOOLS.reject { |tool| command_available?(tool) }
+          missing_tools << 'llc/clang' unless command_available?('llc') || command_available?('clang')
+          missing_tools << 'c++/clang++/g++' unless command_available?('c++') || command_available?('clang++') || command_available?('g++')
+
+          arcilator_help = command_output(%w[arcilator --help])
+          gpu_option_tokens = detect_gpu_option_tokens(arcilator_help)
+          missing_capabilities = []
+          if gpu_option_tokens.nil? || gpu_option_tokens.empty?
+            missing_capabilities << 'ArcToGPU arcilator lowering flag'
+          end
+
+          if macos_host?
+            missing_tools << 'xcrun' unless command_available?('xcrun')
+            missing_tools << 'metal' unless command_success?(%w[xcrun -f metal])
+            missing_tools << 'metallib' unless command_success?(%w[xcrun -f metallib])
+          end
+
+          {
+            ready: missing_tools.empty? && missing_capabilities.empty?,
+            missing_tools: missing_tools.uniq,
+            missing_capabilities: missing_capabilities,
+            gpu_option_tokens: gpu_option_tokens || []
+          }
+        end
+
+        def self.ensure_available!
+          info = status
+          return info if info[:ready]
+
+          details = []
+          details << "missing tools: #{info[:missing_tools].join(', ')}" unless info[:missing_tools].empty?
+          details << "missing capabilities: #{info[:missing_capabilities].join(', ')}" unless info[:missing_capabilities].empty?
+
+          raise ArgumentError,
+            "arcilator_gpu backend unavailable (#{details.join('; ')}). " \
+            "Install an ArcToGPU-enabled arcilator build and required Metal/SPIR-V toolchain tools."
+        end
+
+        def self.detect_gpu_option_tokens(help_text)
+          env_value = ENV['RHDL_ARCILATOR_GPU_OPTION'].to_s.strip
+          return Shellwords.split(env_value) unless env_value.empty?
+
+          text = help_text.to_s
+          return nil if text.empty?
+
+          GPU_OPTION_PATTERNS.each do |opt|
+            return [opt] if text.include?(opt)
+          end
+
+          text.each_line do |line|
+            next unless line.match?(/arc/i) && line.match?(/gpu/i)
+
+            token = line[/--[A-Za-z0-9][A-Za-z0-9\-_=]*/]
+            return [token] if token
+          end
+
+          nil
+        end
+
+        def initialize
+          @backend = :arcilator_gpu
+          @gpu_info = self.class.ensure_available!
+          @gpu_option_tokens = @gpu_info[:gpu_option_tokens]
+          build_simulation
+          load_library
+          reset
+        end
+
+        def native?
+          true
+        end
+
+        def runner_mode?
+          true
+        end
+
+        def runner_kind
+          :cpu8bit
+        end
+
+        def evaluate
+          @fn_sim_eval.call(@ctx)
+          nil
+        end
+
+        def reset
+          @fn_sim_reset.call(@ctx)
+          nil
+        end
+
+        def poke(name, value)
+          @fn_sim_poke.call(@ctx, name.to_s, value.to_i & 0xFFFF_FFFF)
+          true
+        end
+
+        def peek(name)
+          @fn_sim_peek.call(@ctx, name.to_s) & 0xFFFF_FFFF
+        end
+
+        def runner_load_memory(data, offset = 0, _is_rom = false)
+          payload = normalize_payload(data)
+          return false if payload.empty?
+
+          ptr = Fiddle::Pointer[payload]
+          loaded = @fn_runner_load_memory.call(@ctx, ptr, payload.bytesize, offset.to_i & 0xFFFF)
+          loaded.to_i.positive?
+        end
+
+        def runner_read_memory(offset, length, mapped: true)
+          _ = mapped
+          len = [length.to_i, 0].max
+          return [] if len.zero?
+
+          out = Fiddle::Pointer.malloc(len)
+          read_len = @fn_runner_read_memory.call(@ctx, offset.to_i & 0xFFFF, len, out).to_i
+          return [] if read_len <= 0
+
+          out[0, read_len].unpack('C*')
+        end
+
+        def runner_write_memory(offset, data, mapped: true)
+          _ = mapped
+          payload = normalize_payload(data)
+          return 0 if payload.empty?
+
+          ptr = Fiddle::Pointer[payload]
+          @fn_runner_write_memory.call(@ctx, offset.to_i & 0xFFFF, ptr, payload.bytesize).to_i
+        end
+
+        def runner_run_cycles(n, _key_data = 0, _key_ready = false)
+          cycles = @fn_runner_run_cycles.call(@ctx, [n.to_i, 0].max).to_i
+          {
+            text_dirty: false,
+            key_cleared: false,
+            cycles_run: cycles,
+            speaker_toggles: 0
+          }
+        end
+
+        private
+
+        def self.command_available?(tool)
+          ENV.fetch('PATH', '').split(File::PATH_SEPARATOR).any? do |path|
+            File.executable?(File.join(path, tool))
+          end
+        end
+
+        def self.command_output(cmd)
+          out, _status = Open3.capture2e(*cmd)
+          out
+        rescue StandardError
+          ''
+        end
+
+        def self.command_success?(cmd)
+          _out, status = Open3.capture2e(*cmd)
+          status.success?
+        rescue StandardError
+          false
+        end
+
+        def self.macos_host?
+          RUBY_PLATFORM.include?('darwin')
+        end
+
+        def command_available?(tool)
+          self.class.command_available?(tool)
+        end
+
+        def build_simulation
+          FileUtils.mkdir_p(BUILD_DIR)
+
+          fir_file = File.join(BUILD_DIR, 'cpu8bit.fir')
+          mlir_file = File.join(BUILD_DIR, 'cpu8bit_hw.mlir')
+          ll_file = File.join(BUILD_DIR, 'cpu8bit_arcgpu.ll')
+          state_file = File.join(BUILD_DIR, 'cpu8bit_state.json')
+          obj_file = File.join(BUILD_DIR, 'cpu8bit_arcgpu.o')
+          wrapper_file = File.join(BUILD_DIR, 'cpu8bit_arcgpu_wrapper.cpp')
+
+          needs_rebuild = !File.exist?(shared_lib_path)
+
+          if needs_rebuild
+            export_firrtl(fir_file)
+            compile_with_arcilator(fir_file, mlir_file, ll_file, state_file, obj_file)
+            write_wrapper(wrapper_file, state_file)
+            link_shared_library(wrapper_file, obj_file, shared_lib_path)
+          end
+        end
+
+        def export_firrtl(path)
+          ir = RHDL::HDL::CPU::CPU.to_flat_ir(top_name: 'cpu8bit')
+          firrtl = RHDL::Codegen::CIRCT::FIRRTL.generate(ir)
+          File.write(path, firrtl)
+        end
+
+        def compile_with_arcilator(fir_file, mlir_file, ll_file, state_file, obj_file)
+          log_file = File.join(BUILD_DIR, 'cpu8bit_arcilator_gpu.log')
+          File.delete(log_file) if File.exist?(log_file)
+
+          run_or_raise(%W[firtool #{fir_file} --ir-hw -o #{mlir_file}], 'firtool HW lowering', log_file)
+
+          arcilator_cmd = ['arcilator', mlir_file] + @gpu_option_tokens + ["--state-file=#{state_file}", '-o', ll_file]
+          run_or_raise(arcilator_cmd, 'arcilator ArcToGPU lowering', log_file)
+
+          if command_available?('clang')
+            compile_object_with_clang(ll_file: ll_file, obj_file: obj_file, log_file: log_file)
+            return
+          end
+
+          compile_object_with_llc(ll_file: ll_file, obj_file: obj_file, log_file: log_file)
+        end
+
+        def run_or_raise(cmd, step_name, log_file)
+          out, status = Open3.capture2e(*cmd)
+          File.write(log_file, out, mode: 'a')
+          return if status.success?
+
+          raise LoadError, "#{step_name} failed: #{last_log_lines(log_file)}"
+        end
+
+        def compile_object_with_clang(ll_file:, obj_file:, log_file:)
+          cmd = ['clang', '-c', '-O2', '-fPIC']
+          if (target = llc_target_triple)
+            cmd += ['-target', target]
+          end
+          cmd += [ll_file, '-o', obj_file]
+          run_or_raise(cmd, 'clang compile', log_file)
+        end
+
+        def compile_object_with_llc(ll_file:, obj_file:, log_file:)
+          cmd = ['llc', '-filetype=obj', '-O2', '-relocation-model=pic']
+          if (triple = llc_target_triple)
+            cmd << "-mtriple=#{triple}"
+          end
+          cmd += [ll_file, '-o', obj_file]
+          run_or_raise(cmd, 'llc compile', log_file)
+        end
+
+        def llc_target_triple(host_os: RbConfig::CONFIG['host_os'], host_cpu: RbConfig::CONFIG['host_cpu'])
+          return nil unless host_os.to_s.downcase.include?('darwin')
+
+          cpu = host_cpu.to_s.downcase
+          arch = if cpu.include?('arm64') || cpu.include?('aarch64')
+            'arm64'
+          elsif cpu.include?('x86_64') || cpu.include?('amd64')
+            'x86_64'
+          end
+          return nil unless arch
+
+          "#{arch}-apple-macosx"
+        end
+
+        def link_shared_library(wrapper_file, obj_file, output_file)
+          cxx = if command_available?('clang++')
+            'clang++'
+          elsif command_available?('g++')
+            'g++'
+          else
+            'c++'
+          end
+
+          cmd = [cxx, '-shared', '-fPIC', '-O2', '-o', output_file, wrapper_file, obj_file]
+          run_or_raise(cmd, 'C++ link', File.join(BUILD_DIR, 'cpu8bit_arcilator_gpu.log'))
+        end
+
+        def write_wrapper(path, state_path)
+          state = JSON.parse(File.read(state_path))
+          mod = state[0]
+          states = mod.fetch('states', [])
+
+          offsets = {}
+          widths = {}
+          states.each do |entry|
+            name = entry.fetch('name')
+            offsets[name] = entry.fetch('offset')
+            widths[name] = entry.fetch('numBits', 32).to_i
+          end
+
+          missing = REQUIRED_SIGNAL_NAMES.reject { |name| offsets.key?(name) }
+          raise LoadError, "Missing required CPU8bit signals in arcilator state: #{missing.join(', ')}" unless missing.empty?
+
+          defines = []
+          defines << "#define STATE_SIZE #{mod.fetch('numStateBytes')}"
+          offsets.each do |name, offset|
+            defines << "#define #{offset_define(name)} #{offset}"
+          end
+
+          poke_cases = []
+          %w[clk rst mem_data_in pc_reg__q].each do |name|
+            next unless offsets.key?(name)
+
+            poke_cases << "if (!strcmp(name, \"#{name}\")) { #{setter_expr(offset_define(name), widths[name], 'value')}; return; }"
+          end
+
+          peek_cases = []
+          %w[mem_addr mem_data_out mem_write_en halted pc_out acc_out sp_out state_out zero_flag_out].each do |name|
+            peek_cases << "if (!strcmp(name, \"#{name}\")) return #{getter_expr(offset_define(name), widths[name])};"
+          end
+
+          wrapper = <<~CPP
+            #include <cstdint>
+            #include <cstring>
+            #include <cstdlib>
+
+            extern "C" void #{mod.fetch('name')}_eval(void* state);
+
+            #{defines.join("\n")}
+
+            struct SimContext {
+              uint8_t state[STATE_SIZE];
+              uint8_t memory[65536];
+            };
+
+            static inline void set_u8(uint8_t* s, int o, uint8_t v) { s[o] = v; }
+            static inline uint8_t get_u8(uint8_t* s, int o) { return s[o]; }
+            static inline void set_u16(uint8_t* s, int o, uint16_t v) { memcpy(&s[o], &v, 2); }
+            static inline uint16_t get_u16(uint8_t* s, int o) { uint16_t v; memcpy(&v, &s[o], 2); return v; }
+            static inline void set_u32(uint8_t* s, int o, uint32_t v) { memcpy(&s[o], &v, 4); }
+            static inline uint32_t get_u32(uint8_t* s, int o) { uint32_t v; memcpy(&v, &s[o], 4); return v; }
+            static inline void set_bit(uint8_t* s, int o, uint8_t v) { s[o] = v & 1; }
+            static inline uint8_t get_bit(uint8_t* s, int o) { return s[o] & 1; }
+
+            extern "C" {
+            void* sim_create(void) {
+              SimContext* ctx = new SimContext();
+              memset(ctx->state, 0, sizeof(ctx->state));
+              memset(ctx->memory, 0, sizeof(ctx->memory));
+              set_bit(ctx->state, OFF_CLK, 0);
+              set_bit(ctx->state, OFF_RST, 1);
+              #{mod.fetch('name')}_eval(ctx->state);
+              return ctx;
+            }
+
+            void sim_destroy(void* sim) {
+              delete static_cast<SimContext*>(sim);
+            }
+
+            void sim_eval(void* sim) {
+              SimContext* ctx = static_cast<SimContext*>(sim);
+              #{mod.fetch('name')}_eval(ctx->state);
+            }
+
+            static inline unsigned int run_cycles_internal(SimContext* ctx, unsigned int n) {
+              for (unsigned int i = 0; i < n; ++i) {
+                if (get_bit(ctx->state, OFF_HALTED)) {
+                  return i;
+                }
+
+                set_bit(ctx->state, OFF_CLK, 0);
+                #{mod.fetch('name')}_eval(ctx->state);
+
+                uint16_t addr = get_u16(ctx->state, OFF_MEM_ADDR) & 0xFFFF;
+                if (get_bit(ctx->state, OFF_MEM_WRITE_EN)) {
+                  ctx->memory[addr] = get_u8(ctx->state, OFF_MEM_DATA_OUT);
+                }
+                set_u8(ctx->state, OFF_MEM_DATA_IN, ctx->memory[addr]);
+
+                set_bit(ctx->state, OFF_CLK, 1);
+                #{mod.fetch('name')}_eval(ctx->state);
+                if (get_bit(ctx->state, OFF_HALTED)) {
+                  return i + 1;
+                }
+              }
+              return n;
+            }
+
+            void sim_reset(void* sim) {
+              SimContext* ctx = static_cast<SimContext*>(sim);
+              set_bit(ctx->state, OFF_RST, 1);
+              run_cycles_internal(ctx, 1);
+              set_bit(ctx->state, OFF_RST, 0);
+              #{mod.fetch('name')}_eval(ctx->state);
+            }
+
+            void sim_poke(void* sim, const char* name, unsigned int value) {
+              SimContext* ctx = static_cast<SimContext*>(sim);
+              #{poke_cases.join("\n  else ")}
+            }
+
+            unsigned int sim_peek(void* sim, const char* name) {
+              SimContext* ctx = static_cast<SimContext*>(sim);
+              #{peek_cases.join("\n  ")}
+              return 0;
+            }
+
+            unsigned int sim_runner_load_memory(void* sim, const unsigned char* data, unsigned int len, unsigned int offset) {
+              SimContext* ctx = static_cast<SimContext*>(sim);
+              unsigned int loaded = 0;
+              for (unsigned int i = 0; i < len; ++i) {
+                unsigned int addr = (offset + i) & 0xFFFF;
+                ctx->memory[addr] = data[i];
+                loaded++;
+              }
+              return loaded;
+            }
+
+            unsigned int sim_runner_read_memory(void* sim, unsigned int offset, unsigned int len, unsigned char* out) {
+              SimContext* ctx = static_cast<SimContext*>(sim);
+              for (unsigned int i = 0; i < len; ++i) {
+                unsigned int addr = (offset + i) & 0xFFFF;
+                out[i] = ctx->memory[addr];
+              }
+              return len;
+            }
+
+            unsigned int sim_runner_write_memory(void* sim, unsigned int offset, const unsigned char* data, unsigned int len) {
+              SimContext* ctx = static_cast<SimContext*>(sim);
+              for (unsigned int i = 0; i < len; ++i) {
+                unsigned int addr = (offset + i) & 0xFFFF;
+                ctx->memory[addr] = data[i];
+              }
+              return len;
+            }
+
+            unsigned int sim_runner_run_cycles(void* sim, unsigned int n) {
+              SimContext* ctx = static_cast<SimContext*>(sim);
+              return run_cycles_internal(ctx, n);
+            }
+            }
+          CPP
+
+          File.write(path, wrapper)
+        end
+
+        def offset_define(name)
+          "OFF_#{name.to_s.upcase.gsub(/[^A-Z0-9]/, '_')}"
+        end
+
+        def setter_expr(offset_macro, width_bits, source_value)
+          if width_bits <= 1
+            "set_bit(ctx->state, #{offset_macro}, #{source_value})"
+          elsif width_bits <= 8
+            "set_u8(ctx->state, #{offset_macro}, static_cast<uint8_t>(#{source_value}))"
+          elsif width_bits <= 16
+            "set_u16(ctx->state, #{offset_macro}, static_cast<uint16_t>(#{source_value}))"
+          else
+            "set_u32(ctx->state, #{offset_macro}, static_cast<uint32_t>(#{source_value}))"
+          end
+        end
+
+        def getter_expr(offset_macro, width_bits)
+          if width_bits <= 1
+            "get_bit(ctx->state, #{offset_macro})"
+          elsif width_bits <= 8
+            "get_u8(ctx->state, #{offset_macro})"
+          elsif width_bits <= 16
+            "get_u16(ctx->state, #{offset_macro})"
+          else
+            "get_u32(ctx->state, #{offset_macro})"
+          end
+        end
+
+        def load_library
+          @lib = Fiddle.dlopen(shared_lib_path)
+          @fn_sim_create = Fiddle::Function.new(@lib['sim_create'], [], Fiddle::TYPE_VOIDP)
+          @fn_sim_destroy = Fiddle::Function.new(@lib['sim_destroy'], [Fiddle::TYPE_VOIDP], Fiddle::TYPE_VOID)
+          @fn_sim_eval = Fiddle::Function.new(@lib['sim_eval'], [Fiddle::TYPE_VOIDP], Fiddle::TYPE_VOID)
+          @fn_sim_reset = Fiddle::Function.new(@lib['sim_reset'], [Fiddle::TYPE_VOIDP], Fiddle::TYPE_VOID)
+          @fn_sim_poke = Fiddle::Function.new(@lib['sim_poke'], [Fiddle::TYPE_VOIDP, Fiddle::TYPE_VOIDP, Fiddle::TYPE_UINT], Fiddle::TYPE_VOID)
+          @fn_sim_peek = Fiddle::Function.new(@lib['sim_peek'], [Fiddle::TYPE_VOIDP, Fiddle::TYPE_VOIDP], Fiddle::TYPE_UINT)
+          @fn_runner_load_memory = Fiddle::Function.new(
+            @lib['sim_runner_load_memory'],
+            [Fiddle::TYPE_VOIDP, Fiddle::TYPE_VOIDP, Fiddle::TYPE_UINT, Fiddle::TYPE_UINT],
+            Fiddle::TYPE_UINT
+          )
+          @fn_runner_read_memory = Fiddle::Function.new(
+            @lib['sim_runner_read_memory'],
+            [Fiddle::TYPE_VOIDP, Fiddle::TYPE_UINT, Fiddle::TYPE_UINT, Fiddle::TYPE_VOIDP],
+            Fiddle::TYPE_UINT
+          )
+          @fn_runner_write_memory = Fiddle::Function.new(
+            @lib['sim_runner_write_memory'],
+            [Fiddle::TYPE_VOIDP, Fiddle::TYPE_UINT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_UINT],
+            Fiddle::TYPE_UINT
+          )
+          @fn_runner_run_cycles = Fiddle::Function.new(
+            @lib['sim_runner_run_cycles'],
+            [Fiddle::TYPE_VOIDP, Fiddle::TYPE_UINT],
+            Fiddle::TYPE_UINT
+          )
+
+          @ctx = @fn_sim_create.call
+          ObjectSpace.define_finalizer(self, self.class.finalizer(@fn_sim_destroy, @ctx))
+        end
+
+        def self.finalizer(destroy_fn, ctx)
+          proc { destroy_fn.call(ctx) if ctx && !ctx.to_i.zero? }
+        end
+
+        def shared_lib_path
+          ext = if RbConfig::CONFIG['host_os'] =~ /darwin/
+            '.dylib'
+          elsif RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
+            '.dll'
+          else
+            '.so'
+          end
+          File.join(BUILD_DIR, "libcpu8bit_arcgpu_sim#{ext}")
+        end
+
+        def normalize_payload(data)
+          case data
+          when String
+            data.b
+          when Array
+            data.pack('C*')
+          else
+            Array(data).pack('C*')
+          end
+        end
+
+        def last_log_lines(path, count: 8)
+          return 'unknown error' unless File.exist?(path)
+
+          File.read(path).lines.last(count).join.strip
+        rescue StandardError
+          'unknown error'
+        end
+      end
+    end
+  end
+end

--- a/lib/rhdl/cli/tasks/benchmark_task.rb
+++ b/lib/rhdl/cli/tasks/benchmark_task.rb
@@ -22,6 +22,8 @@ module RHDL
             benchmark_apple2
           when :mos6502
             benchmark_mos6502
+          when :cpu8bit
+            benchmark_cpu8bit
           when :gameboy
             benchmark_gameboy
           when :riscv
@@ -200,6 +202,98 @@ module RHDL
             rate = r[:examples] > 0 ? format('%.1f', r[:examples] / r[:time]) : 'N/A'
             puts "#{r[:name].ljust(20)} #{format('%8.2f', r[:time])}s #{r[:examples].to_s.rjust(8)} #{r[:files].to_s.rjust(8)} #{rate.rjust(8)} t/s"
           end
+        end
+
+        # Benchmark 8-bit CPU FastHarness native backends.
+        def benchmark_cpu8bit
+          require 'rhdl/codegen'
+          require_relative '../../../../examples/8bit/hdl/cpu/harness'
+
+          cycles = options[:cycles] || 5_000_000
+          batch_size = options[:batch_size] || 4096
+          runner_filter = (ENV['RHDL_BENCH_BACKENDS'] || '')
+            .split(',')
+            .map { |name| name.strip.downcase.to_sym }
+            .map { |name| name == :gpu ? :arcilator_gpu : name }
+            .reject(&:empty?)
+
+          puts_header("8-bit CPU FastHarness Benchmark")
+          puts "Cycles per run: #{cycles}"
+          puts "Batch size: #{batch_size}"
+          puts
+
+          # JMP_LONG 0x0000 (infinite loop)
+          loop_program = [0xF9, 0x00, 0x00].freeze
+
+          runners = [
+            {
+              name: 'Compiler',
+              sim: :compile,
+              filter_key: :compiler,
+              available: RHDL::Codegen::IR::IR_COMPILER_AVAILABLE
+            },
+            {
+              name: 'ArcilatorGPU',
+              sim: :arcilator_gpu,
+              filter_key: :arcilator_gpu,
+              available: RHDL::HDL::CPU::FastHarness.arcilator_gpu_status[:ready]
+            }
+          ]
+          runners.select! { |runner| runner_filter.include?(runner[:filter_key]) } unless runner_filter.empty?
+
+          results = []
+
+          runners.each do |runner|
+            unless runner[:available]
+              puts "\n#{runner[:name]}: SKIPPED (not available)"
+              results << { name: runner[:name], status: :skipped }
+              next
+            end
+
+            print "\n#{runner[:name]}: "
+            $stdout.flush
+
+            begin
+              print 'initializing... '
+              $stdout.flush
+              init_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+              sim = RHDL::HDL::CPU::FastHarness.new(nil, sim: runner[:sim])
+              sim.memory.load(loop_program, 0)
+              sim.pc = 0
+              init_elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - init_start
+
+              print "running #{cycles} cycles... "
+              $stdout.flush
+              run_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+              cycles_run = sim.run_cycles(cycles, batch_size: batch_size)
+              run_elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - run_start
+
+              cycles_per_sec = cycles_run / run_elapsed
+              final_pc = sim.pc
+
+              puts 'done'
+              puts "  Init time:  #{format('%.3f', init_elapsed)}s"
+              puts "  Run time:   #{format('%.3f', run_elapsed)}s"
+              puts "  Cycles run: #{cycles_run}"
+              puts "  Final PC:   0x#{final_pc.to_s(16).upcase}"
+
+              results << {
+                name: runner[:name],
+                status: :success,
+                init_time: init_elapsed,
+                run_time: run_elapsed,
+                cycles_per_sec: cycles_per_sec,
+                final_pc: final_pc
+              }
+            rescue => e
+              puts 'FAILED'
+              puts "  Error: #{e.message}"
+              puts "  #{e.backtrace.first(3).join("\n  ")}" if options[:verbose]
+              results << { name: runner[:name], status: :failed, error: e.message }
+            end
+          end
+
+          print_benchmark_summary(results, cycles)
         end
 
         # Benchmark MOS6502 CPU IR with memory bridging (like karateka tests)

--- a/lib/rhdl/cli/tasks/deps_task.rb
+++ b/lib/rhdl/cli/tasks/deps_task.rb
@@ -15,6 +15,8 @@ module RHDL
         def run
           if options[:check]
             check_status
+          elsif options[:check_gpu]
+            check_gpu_status(strict: options[:strict_gpu] == true)
           else
             install
           end
@@ -104,6 +106,26 @@ module RHDL
             end
           end
 
+          # Check ArcToGPU / Metal path prerequisites (optional)
+          puts
+          arcilator_gpu_health_checks = arcilator_gpu_tool_health_checks(platform: platform)
+          missing_arcilator_gpu_tools = arcilator_gpu_health_checks.keys.reject do |tool|
+            tool_healthy?(tool, arcilator_gpu_health_checks.fetch(tool))
+          end
+
+          if missing_arcilator_gpu_tools.empty?
+            puts "[OK] ArcToGPU/Metal prerequisites are installed"
+          else
+            puts "[OPTIONAL] ArcToGPU/Metal prerequisites missing or broken: #{missing_arcilator_gpu_tools.join(', ')}"
+            if platform == :macos
+              puts "  Install/verify with:"
+              puts "    xcode-select --install"
+              puts "    brew install spirv-cross llvm"
+            else
+              puts "  Install LLVM tools (mlir-opt/llc) and spirv-cross for ArcToGPU pipelines."
+            end
+          end
+
           # Check for graphviz (dot)
           puts
           dot_available = command_available?('dot')
@@ -169,6 +191,8 @@ module RHDL
             'verilator' => { cmd: 'verilator --version', optional: true, desc: 'Verilator (for high-performance Verilog simulation)' },
             'firtool' => { cmd: 'firtool --version', optional: true, desc: 'CIRCT firtool (for Arcilator HDL simulation)' },
             'arcilator' => { cmd: 'arcilator --version', optional: true, desc: 'CIRCT Arcilator (cycle-based HDL simulator)' },
+            'mlir-opt' => { cmd: 'mlir-opt --version', optional: true, desc: 'MLIR optimizer (GPU/SPIR-V lowering passes)' },
+            'spirv-cross' => { cmd: 'spirv-cross --version', optional: true, desc: 'SPIR-V to Metal shader cross-compiler' },
             'dot' => { cmd: 'dot -V', optional: true, desc: 'Graphviz (for diagram rendering)' },
             'bun' => { cmd: 'bun --version', optional: true, desc: 'Bun (for web and desktop tooling)' },
             'ruby' => { cmd: 'ruby --version', optional: false, desc: 'Ruby interpreter' },
@@ -184,11 +208,68 @@ module RHDL
             puts "             #{version}" if available
           end
 
+          if detect_platform == :macos
+            metal_tools = {
+              'metal' => 'xcrun -f metal',
+              'metallib' => 'xcrun -f metallib'
+            }
+
+            metal_tools.each do |name, cmd|
+              available = tool_healthy?(name, cmd)
+              status = available ? "[OK]" : "[OPTIONAL]"
+              puts "#{status.ljust(12)} #{name.ljust(12)} - Xcode Metal toolchain utility"
+              puts "             #{command_output_first_line(cmd)}" if available
+            end
+          end
+
           puts
           puts "Run 'bundle exec rake deps' to install missing dependencies."
         end
 
+        # Check ArcToGPU toolchain prerequisites and fail fast when strict.
+        def check_gpu_status(strict: false)
+          puts_header("RHDL ArcToGPU Toolchain Status")
+
+          status = arcilator_gpu_runner_status
+          if status[:ready]
+            puts "[OK] ArcToGPU runner prerequisites are satisfied"
+            if status[:gpu_option_tokens] && !status[:gpu_option_tokens].empty?
+              puts "     ArcToGPU option: #{status[:gpu_option_tokens].join(' ')}"
+            end
+            return true
+          end
+
+          puts "[MISSING] ArcToGPU runner prerequisites are not satisfied"
+          unless status[:missing_tools].nil? || status[:missing_tools].empty?
+            puts "          missing tools: #{status[:missing_tools].join(', ')}"
+          end
+          unless status[:missing_capabilities].nil? || status[:missing_capabilities].empty?
+            puts "          missing capabilities: #{status[:missing_capabilities].join(', ')}"
+          end
+
+          if strict
+            details = []
+            details << "missing tools: #{status[:missing_tools].join(', ')}" unless status[:missing_tools].nil? || status[:missing_tools].empty?
+            details << "missing capabilities: #{status[:missing_capabilities].join(', ')}" unless status[:missing_capabilities].nil? || status[:missing_capabilities].empty?
+            raise "ArcToGPU toolchain check failed (#{details.join('; ')})"
+          end
+
+          false
+        end
+
         private
+
+        def arcilator_gpu_runner_status
+          require_relative '../../../../examples/8bit/utilities/runners/arcilator_gpu_runner'
+          RHDL::Examples::CPU8Bit::ArcilatorGpuRunner.status
+        rescue LoadError, StandardError => e
+          {
+            ready: false,
+            missing_tools: [],
+            missing_capabilities: ["status probe failed: #{e.message}"],
+            gpu_option_tokens: []
+          }
+        end
 
         def arcilator_tool_health_checks
           {
@@ -196,6 +277,31 @@ module RHDL
             'arcilator' => 'arcilator --version',
             'llc' => 'llc --version'
           }
+        end
+
+        def arcilator_gpu_tool_health_checks(platform:)
+          checks = {
+            'mlir-opt' => 'mlir-opt --version',
+            'spirv-cross' => 'spirv-cross --version',
+            'llc' => 'llc --version'
+          }
+
+          if platform == :macos
+            checks['xcrun'] = 'xcrun --version'
+            checks['metal'] = 'xcrun -f metal'
+            checks['metallib'] = 'xcrun -f metallib'
+          end
+
+          checks
+        end
+
+        def tool_healthy?(tool, check_command)
+          if %w[metal metallib].include?(tool)
+            _out, status = run_command_with_timeout(check_command)
+            return status&.success? || false
+          end
+
+          command_healthy?(tool, check_command)
         end
 
         def command_healthy?(tool, version_cmd)

--- a/prd/2026_03_03_arc_to_gpu_cpu8bit_prd.md
+++ b/prd/2026_03_03_arc_to_gpu_cpu8bit_prd.md
@@ -1,0 +1,87 @@
+# Arc -> ArcToGPU -> MLIR GPU Gap (CPU8bit Slice)
+
+**Status:** Completed
+**Date:** 2026-03-03
+
+## Context
+
+RHDL already supports native 8-bit CPU execution through IR backends, but it lacks an end-to-end integration path for an ArcToGPU-enabled execution mode in the native runner flow. We need an incremental path that is useful immediately while preserving clear seams for the real ArcToGPU backend landing.
+
+This PRD tracks the staged implementation for the `examples/8bit` first target.
+
+## Goals
+
+1. Add a first-class `:arcilator_gpu` mode to 8-bit native execution.
+2. Make prerequisite/tooling checks explicit (MLIR/SPIR-V/Metal path).
+3. Add benchmark wiring for 8-bit native GPU-path comparisons.
+4. Keep cycle execution semantics stable for parity validation.
+
+## Non-Goals
+
+1. Implement the full ArcToGPU lowering inside CIRCT in this repo.
+2. Web simulator integration for this backend in this phase.
+3. Large-system migration (Apple II, RISC-V) before 8-bit stabilization.
+
+## Phased Plan
+
+### Phase 1: FastHarness ArcToGPU Mode Shell
+
+**Red:** No `:arcilator_gpu` mode; no clear capability failures.
+**Green:** `FastHarness.new(sim: :arcilator_gpu)` exists, uses runner-backed memory, and fails with actionable errors when ArcToGPU prerequisites are missing.
+
+Exit criteria:
+1. New runner-backed memory adapter is in place.
+2. `:arcilator_gpu` mode validates runner kind and capability checks.
+3. Specs cover success path and expected failure paths.
+
+### Phase 2: Dependency Surface and Benchmark Integration
+
+**Red:** `deps:check` does not report MLIR/SPIR-V/Metal prerequisites; no 8-bit benchmark scope for GPU path.
+**Green:** Dependency checks include ArcToGPU prerequisites, `deps:check_gpu` fails fast for missing GPU toolchain, and `bench:native[cpu8bit,...]` benchmarks compiler vs `:arcilator_gpu`.
+
+Exit criteria:
+1. `DepsTask` reports `mlir-opt`, `spirv-cross`, and Metal tool presence (macOS).
+2. `deps:check_gpu` fails fast when ArcToGPU prerequisites/capabilities are missing.
+3. `BenchmarkTask` supports `type: :cpu8bit`.
+4. `Rakefile` exposes `bench:native[cpu8bit,<cycles>]`.
+5. Rake/spec dispatch coverage is green.
+
+### Phase 3: Real ArcToGPU Artifact Execution
+
+**Red:** `:arcilator_gpu` still routes through existing compiler runner ABI bridge.
+**Green:** `:arcilator_gpu` executes with a true ArcToGPU-generated native artifact path.
+
+Exit criteria:
+1. Harness no longer relies on compiler backend shim for GPU mode.
+2. Build/invoke path for ArcToGPU artifacts is documented and testable.
+3. Parity checks verify cycle-exact behavior on representative 8-bit programs.
+
+## Acceptance Criteria
+
+1. Users can instantiate 8-bit FastHarness with `sim: :arcilator_gpu`.
+2. Missing ArcToGPU prerequisites produce explicit, actionable messages.
+3. `bundle exec rake deps:check` reports ArcToGPU-related tool status.
+4. `bundle exec rake deps:check_gpu` fails fast when ArcToGPU toolchain is incomplete.
+5. `bundle exec rake bench:native[cpu8bit]` is available and functional.
+6. Targeted specs for new routing and checks are green.
+
+## Risks and Mitigations
+
+1. Risk: ArcToGPU features vary across local arcilator builds.
+   Mitigation: Gate with explicit capability checks and clear failure text.
+2. Risk: Benchmark behavior could be misleading if programs halt early.
+   Mitigation: Use an explicit infinite-loop workload for fixed-cycle runs.
+3. Risk: Platform-specific tool detection can be flaky.
+   Mitigation: Keep checks command-based and treat missing optional tools as non-fatal.
+
+## Implementation Checklist
+
+- [x] Phase 1: Add `:arcilator_gpu` mode in 8-bit FastHarness.
+- [x] Phase 1: Add runner-backed 64K memory adapter.
+- [x] Phase 1: Add capability-gating specs for fast harness mode.
+- [x] Phase 2: Extend dependency checks for ArcToGPU/Metal prerequisites.
+- [x] Phase 2: Add strict fail-fast ArcToGPU toolchain task (`deps:check_gpu`).
+- [x] Phase 2: Add `BenchmarkTask` CPU8bit benchmark mode.
+- [x] Phase 2: Add `bench:native[cpu8bit]` Rake wiring and specs.
+- [x] Phase 3: Replace compiler-bridge execution with dedicated arcilator GPU runner artifact path (gated by tool/capability detection).
+- [x] Phase 3: Add cycle-exact parity suite specifically for ArcToGPU path (gated/pending when ArcToGPU toolchain is unavailable).

--- a/spec/examples/8bit/hdl/cpu/arcilator_gpu_parity_spec.rb
+++ b/spec/examples/8bit/hdl/cpu/arcilator_gpu_parity_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe '8-bit CPU arcilator_gpu parity' do
+  def build_harness(sim)
+    RHDL::HDL::CPU::FastHarness.new(nil, sim: sim)
+  end
+
+  it 'matches compiler backend for a simple store program' do
+    skip 'set RHDL_ENABLE_ARCILATOR_GPU=1 to run ArcToGPU parity checks' unless ENV['RHDL_ENABLE_ARCILATOR_GPU'] == '1'
+    skip 'IR compiler backend unavailable' unless RHDL::Codegen::IR::IR_COMPILER_AVAILABLE
+
+    gpu_status = RHDL::HDL::CPU::FastHarness.arcilator_gpu_status
+    expect(gpu_status[:ready]).to be(true), "arcilator_gpu backend unavailable: #{gpu_status.inspect}"
+
+    compiler = build_harness(:compile)
+    gpu = build_harness(:arcilator_gpu)
+
+    # LDI 0x55 ; STA 0x40 ; HLT
+    program = [0xA0, 0x55, 0x21, 0x40, 0xF0]
+
+    [compiler, gpu].each do |harness|
+      harness.memory.load(program, 0)
+      harness.pc = 0
+      harness.run(300)
+    end
+
+    expect(gpu.halted).to eq(compiler.halted)
+    expect(gpu.acc).to eq(compiler.acc)
+    expect(gpu.pc).to eq(compiler.pc)
+    expect(gpu.memory.read(0x40)).to eq(compiler.memory.read(0x40))
+  end
+end

--- a/spec/examples/8bit/hdl/cpu/fast_harness_arcilator_gpu_spec.rb
+++ b/spec/examples/8bit/hdl/cpu/fast_harness_arcilator_gpu_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../../../../examples/8bit/utilities/runners/arcilator_gpu_runner'
+
+RSpec.describe RHDL::HDL::CPU::FastHarness do
+  let(:sim) do
+    instance_double(
+      RHDL::Examples::CPU8Bit::ArcilatorGpuRunner,
+      native?: true,
+      backend: :arcilator_gpu,
+      runner_mode?: true,
+      runner_kind: :cpu8bit,
+      poke: true,
+      evaluate: true
+    )
+  end
+
+  before do
+    allow(RHDL::Examples::CPU8Bit::ArcilatorGpuRunner).to receive(:new).and_return(sim)
+    allow(described_class).to receive(:ensure_arcilator_gpu_available!).and_return(true)
+
+    @runner_mem = Array.new(0x10000, 0)
+    allow(sim).to receive(:runner_load_memory) do |data, offset, _is_rom|
+      bytes = data.is_a?(String) ? data.bytes : data
+      bytes.each_with_index { |byte, i| @runner_mem[(offset + i) & 0xFFFF] = byte & 0xFF }
+      true
+    end
+    allow(sim).to receive(:runner_read_memory) do |offset, length, mapped:|
+      expect(mapped).to eq(false)
+      Array.new(length) { |i| @runner_mem[(offset + i) & 0xFFFF] }
+    end
+    allow(sim).to receive(:runner_write_memory) do |offset, data, mapped:|
+      expect(mapped).to eq(false)
+      bytes = data.is_a?(String) ? data.bytes : data
+      bytes.each_with_index { |byte, i| @runner_mem[(offset + i) & 0xFFFF] = byte & 0xFF }
+      bytes.length
+    end
+    allow(sim).to receive(:runner_run_cycles).and_return({ cycles_run: 1, text_dirty: false, key_cleared: false, speaker_toggles: 0 })
+    allow(sim).to receive(:peek).and_return(0)
+  end
+
+  it 'uses runner-backed memory in arcilator_gpu mode' do
+    harness = described_class.new(nil, sim: :arcilator_gpu)
+
+    harness.memory.load([0xAA, 0xBB, 0xCC], 0x20)
+    harness.memory.write(0x40, 0x55)
+
+    expect(harness.memory.read(0x20)).to eq(0xAA)
+    expect(harness.memory.read(0x21)).to eq(0xBB)
+    expect(harness.memory.read(0x40)).to eq(0x55)
+    expect(harness.backend).to eq(:arcilator_gpu)
+    expect(harness.native?).to be(true)
+  end
+
+  it 'requires runner-capable cpu8bit mode for arcilator_gpu' do
+    allow(sim).to receive(:runner_mode?).and_return(false)
+
+    expect { described_class.new(nil, sim: :arcilator_gpu) }
+      .to raise_error(ArgumentError, /runner mode/i)
+  end
+
+  it 'surfaces ArcToGPU capability failures clearly' do
+    allow(described_class).to receive(:ensure_arcilator_gpu_available!)
+      .and_raise(ArgumentError, 'ArcToGPU pipeline not available in arcilator build')
+
+    expect { described_class.new(nil, sim: :arcilator_gpu) }
+      .to raise_error(ArgumentError, /ArcToGPU pipeline not available/)
+  end
+
+  it 'stops batch execution when runner reports no forward progress' do
+    allow(sim).to receive(:runner_run_cycles).and_return({ cycles_run: 0, text_dirty: false, key_cleared: false, speaker_toggles: 0 })
+    allow(sim).to receive(:peek).with('halted').and_return(1)
+
+    harness = described_class.new(nil, sim: :arcilator_gpu)
+    expect(harness.run_cycles(64, batch_size: 16)).to eq(0)
+    expect(harness.halted).to be(true)
+  end
+end

--- a/spec/examples/8bit/utilities/runners/arcilator_gpu_runner_spec.rb
+++ b/spec/examples/8bit/utilities/runners/arcilator_gpu_runner_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../../../../examples/8bit/utilities/runners/arcilator_gpu_runner'
+
+RSpec.describe RHDL::Examples::CPU8Bit::ArcilatorGpuRunner do
+  describe '.detect_gpu_option_tokens' do
+    around do |example|
+      original = ENV['RHDL_ARCILATOR_GPU_OPTION']
+      begin
+        example.run
+      ensure
+        ENV['RHDL_ARCILATOR_GPU_OPTION'] = original
+      end
+    end
+
+    it 'prefers explicit environment override' do
+      ENV['RHDL_ARCILATOR_GPU_OPTION'] = '--lowering=arc-to-gpu --emit-metal'
+
+      tokens = described_class.detect_gpu_option_tokens('arcilator help text without gpu option')
+      expect(tokens).to eq(['--lowering=arc-to-gpu', '--emit-metal'])
+    end
+
+    it 'detects ArcToGPU option from arcilator help text' do
+      tokens = described_class.detect_gpu_option_tokens("Usage:\n  --arc-to-gpu  Lower ARC dialect to GPU\n")
+      expect(tokens).to eq(['--arc-to-gpu'])
+    end
+  end
+
+  describe '.status' do
+    before do
+      allow(described_class).to receive(:macos_host?).and_return(false)
+      allow(described_class).to receive(:command_success?).and_return(true)
+    end
+
+    it 'reports ready when tools and gpu option are available' do
+      allow(described_class).to receive(:command_available?).and_return(true)
+      allow(described_class).to receive(:command_output).with(%w[arcilator --help]).and_return('--arc-to-gpu')
+
+      status = described_class.status
+      expect(status[:ready]).to be(true)
+      expect(status[:missing_tools]).to eq([])
+      expect(status[:missing_capabilities]).to eq([])
+      expect(status[:gpu_option_tokens]).to eq(['--arc-to-gpu'])
+    end
+
+    it 'reports missing ArcToGPU capability when no gpu option is present' do
+      allow(described_class).to receive(:command_available?).and_return(true)
+      allow(described_class).to receive(:command_output).with(%w[arcilator --help]).and_return('--help')
+
+      status = described_class.status
+      expect(status[:ready]).to be(false)
+      expect(status[:missing_capabilities]).to include(/ArcToGPU/)
+    end
+  end
+end

--- a/spec/rhdl/cli/rakefile_interface_spec.rb
+++ b/spec/rhdl/cli/rakefile_interface_spec.rb
@@ -50,6 +50,11 @@ RSpec.describe 'Rakefile interface' do
       expect_task_class(RHDL::CLI::Tasks::DepsTask, check: true)
       Rake::Task['deps:check'].invoke
     end
+
+    it 'deps:check_gpu invokes DepsTask with strict gpu check options' do
+      expect_task_class(RHDL::CLI::Tasks::DepsTask, check_gpu: true, strict_gpu: true)
+      Rake::Task['deps:check_gpu'].invoke
+    end
   end
 
   describe 'bench tasks' do
@@ -69,6 +74,19 @@ RSpec.describe 'Rakefile interface' do
       end
 
       Rake::Task['bench:native'].invoke('ir')
+    end
+
+    it 'bench:native :cpu8bit scope invokes BenchmarkTask with type: :cpu8bit and cycles' do
+      task_instance = instance_double(RHDL::CLI::Tasks::BenchmarkTask)
+      allow(task_instance).to receive(:run)
+
+      expect(RHDL::CLI::Tasks::BenchmarkTask).to receive(:new) do |opts|
+        expect(opts[:type]).to eq(:cpu8bit)
+        expect(opts[:cycles]).to be_a(Integer)
+        task_instance
+      end
+
+      Rake::Task['bench:native'].invoke('cpu8bit')
     end
 
     it 'bench:web scope riscv invokes BenchmarkTask with type: :web_riscv and cycles' do
@@ -327,7 +345,7 @@ RSpec.describe 'Rakefile interface' do
         spec pspec
         spec:bench spec:bench:timing spec:bench:quick
         pspec:n pspec:prepare pspec:balanced
-        deps deps:install deps:check
+        deps deps:install deps:check deps:check_gpu
         bench:native bench:web
         gem:build gem:build:checksum gem:install gem:install:local gem:release
         native:build native:clean native:check

--- a/spec/rhdl/cli/tasks/benchmark_task_spec.rb
+++ b/spec/rhdl/cli/tasks/benchmark_task_spec.rb
@@ -70,6 +70,14 @@ RSpec.describe RHDL::CLI::Tasks::BenchmarkTask do
         task.run
       end
     end
+
+    context 'with type: :cpu8bit' do
+      it 'dispatches to benchmark_cpu8bit' do
+        task = described_class.new(type: :cpu8bit)
+        expect(task).to receive(:benchmark_cpu8bit)
+        task.run
+      end
+    end
   end
 
   describe '#benchmark_gates' do

--- a/spec/rhdl/cli/tasks/deps_task_spec.rb
+++ b/spec/rhdl/cli/tasks/deps_task_spec.rb
@@ -12,9 +12,31 @@ RSpec.describe RHDL::CLI::Tasks::DepsTask do
     it 'can be instantiated with check option' do
       expect { described_class.new(check: true) }.not_to raise_error
     end
+
+    it 'can be instantiated with check_gpu option' do
+      expect { described_class.new(check_gpu: true) }.not_to raise_error
+    end
   end
 
   describe '#run' do
+    context 'with check_gpu option' do
+      it 'dispatches to gpu toolchain check' do
+        task = described_class.new(check_gpu: true)
+        allow(task).to receive(:check_gpu_status).and_return(true)
+
+        task.run
+        expect(task).to have_received(:check_gpu_status).with(strict: false)
+      end
+
+      it 'passes strict flag through to gpu toolchain check' do
+        task = described_class.new(check_gpu: true, strict_gpu: true)
+        allow(task).to receive(:check_gpu_status).and_return(true)
+
+        task.run
+        expect(task).to have_received(:check_gpu_status).with(strict: true)
+      end
+    end
+
     context 'with check option' do
       it 'displays dependency status' do
         task = described_class.new(check: true)
@@ -56,6 +78,18 @@ RSpec.describe RHDL::CLI::Tasks::DepsTask do
         task = described_class.new(check: true)
 
         expect { task.run }.to output(/arcilator/).to_stdout
+      end
+
+      it 'shows mlir-opt in dependency check' do
+        task = described_class.new(check: true)
+
+        expect { task.run }.to output(/mlir-opt/).to_stdout
+      end
+
+      it 'shows spirv-cross in dependency check' do
+        task = described_class.new(check: true)
+
+        expect { task.run }.to output(/spirv-cross/).to_stdout
       end
     end
 
@@ -176,9 +210,48 @@ RSpec.describe RHDL::CLI::Tasks::DepsTask do
       expect(output).to match(/\[(OK|OPTIONAL)\]/)
     end
 
+    it 'shows mlir-opt status' do
+      output = capture_stdout { task.check_status }
+      expect(output).to match(/mlir-opt/)
+      expect(output).to match(/\[(OK|OPTIONAL)\]/)
+    end
+
+    it 'shows spirv-cross status' do
+      output = capture_stdout { task.check_status }
+      expect(output).to match(/spirv-cross/)
+      expect(output).to match(/\[(OK|OPTIONAL)\]/)
+    end
+
     it 'shows the correct install command hint' do
       output = capture_stdout { task.check_status }
       expect(output).to include("bundle exec rake deps")
+    end
+  end
+
+  describe '#check_gpu_status' do
+    let(:task) { described_class.new(check_gpu: true) }
+
+    it 'reports success when ArcToGPU prerequisites are ready' do
+      allow(task).to receive(:arcilator_gpu_runner_status).and_return(
+        ready: true,
+        missing_tools: [],
+        missing_capabilities: [],
+        gpu_option_tokens: ['--arc-to-gpu']
+      )
+
+      output = capture_stdout { expect(task.check_gpu_status).to be(true) }
+      expect(output).to include('ArcToGPU runner prerequisites are satisfied')
+    end
+
+    it 'raises in strict mode when ArcToGPU prerequisites are missing' do
+      allow(task).to receive(:arcilator_gpu_runner_status).and_return(
+        ready: false,
+        missing_tools: ['spirv-cross'],
+        missing_capabilities: ['ArcToGPU arcilator lowering flag'],
+        gpu_option_tokens: []
+      )
+
+      expect { task.check_gpu_status(strict: true) }.to raise_error(/ArcToGPU toolchain check failed/)
     end
   end
 


### PR DESCRIPTION
## Summary
Add an initial `Arc -> ArcToGPU -> native artifact` execution path for the 8-bit CPU FastHarness, with explicit toolchain gating, dependency checks, benchmark wiring, and parity scaffolding.

## What Changed
- Added a dedicated ArcToGPU runner:
  - `examples/8bit/utilities/runners/arcilator_gpu_runner.rb`
  - Builds and loads native simulation artifacts from FIRRTL/MLIR/arcilator output.
  - Implements runner memory/cycle ABI for FastHarness integration.
- Integrated FastHarness GPU mode:
  - `FastHarness.new(sim: :arcilator_gpu)` now uses the dedicated runner and runner-backed memory.
  - Added explicit capability/runner-kind checks and clearer failure messages.
  - Fixed batch cycle accounting to stop on no-progress/halt and avoid over-counting.
- Added dependency surface and strict gate:
  - `deps:check` now reports ArcToGPU-related prerequisites (`mlir-opt`, `spirv-cross`, Metal tools on macOS).
  - New `deps:check_gpu` task fails fast when ArcToGPU prerequisites/capabilities are missing.
- Added benchmark support:
  - New `bench:native[cpu8bit,<cycles>]` scope for compiler vs arcilator_gpu comparison.
- Added tests:
  - FastHarness ArcToGPU mode behavior and failure-path coverage.
  - ArcilatorGpuRunner status/option detection coverage.
  - CLI task/rake wiring for `deps:check_gpu` and `bench:native[cpu8bit]`.
  - Env-gated ArcToGPU parity spec against compiler backend.
- Updated docs and PRD:
  - README + simulation/performance docs for new benchmark/dependency commands.
  - Added PRD and marked it completed.
- Added generated artifact ignore:
  - `.arcilator_gpu_build/`

## Validation
Executed locally:
- `bundle exec rspec spec/examples/8bit/hdl/cpu spec/examples/8bit/utilities/runners/arcilator_gpu_runner_spec.rb spec/rhdl/cli/tasks/deps_task_spec.rb spec/rhdl/cli/tasks/benchmark_task_spec.rb spec/rhdl/cli/rakefile_interface_spec.rb`
  - Result: `251 examples, 0 failures, 1 pending`
  - Pending is expected: env-gated ArcToGPU parity spec (`RHDL_ENABLE_ARCILATOR_GPU=1`).
- `bundle exec rake 'bench:native[cpu8bit,1000]'`
  - Compiler path runs; ArcilatorGPU path is skipped when unavailable.
- `bundle exec rake deps:check_gpu`
  - Fails fast as designed when toolchain/capability is incomplete.

## Notes
- This PR does not implement CIRCT ArcToGPU lowering itself; it wires the execution/validation seam in RHDL for ArcToGPU-enabled toolchains.
