### PR TITLE
CI: increase parallel RSpec timeout to reduce false failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,4 +69,5 @@ jobs:
       - name: Run test suite (parallel)
         env:
           RSPEC_QUIET_OUTPUT: "1"
+          RSPEC_TIMEOUT: "20"
         run: bundle exec rake pspec


### PR DESCRIPTION
## Summary
Increase the default per-example RSpec timeout in GitHub Actions parallel test runs from `10s` to `20s`.

## Why
The merged ArcToGPU PR's CI run failed repeatedly due to `Timeout::Error` in several RISC-V examples under parallel load, while the same tests pass locally. This indicates CI scheduling/resource sensitivity rather than deterministic functional regressions.

Reference failing run:
- https://github.com/skryl/rhdl/actions/runs/22643596519

## Change
- `.github/workflows/tests.yml`
  - In `Run test suite (parallel)` step, set:
    - `RSPEC_TIMEOUT: "20"`

This affects CI runtime guards only and does not alter test logic.

## Risk
- Slightly longer wait before timeout on genuinely hung fast tests.
- Mitigated by preserving the timeout mechanism and only adjusting CI env.
